### PR TITLE
TES-304: Added configuration overrides for GraphDB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,10 +84,13 @@ module "configuration" {
   source = "./modules/configuration"
 
   resource_group_name = azurerm_resource_group.graphdb.name
+  identity_name       = module.identity.identity_name
+  key_vault_name      = module.vault.key_vault_name
 
-  identity_name        = module.identity.identity_name
-  graphdb_license_path = var.graphdb_license_path
-  key_vault_name       = module.vault.key_vault_name
+  graphdb_license_path    = var.graphdb_license_path
+  graphdb_cluster_token   = var.graphdb_cluster_token
+  graphdb_properties_path = var.graphdb_properties_path
+  graphdb_java_options    = var.graphdb_java_options
 
   tags = local.tags
 

--- a/modules/configuration/main.tf
+++ b/modules/configuration/main.tf
@@ -8,6 +8,16 @@ data "azurerm_key_vault" "graphdb" {
   resource_group_name = var.resource_group_name
 }
 
+resource "random_password" "graphdb-cluster-token" {
+  count   = var.graphdb_cluster_token != null ? 0 : 1
+  length  = 16
+  special = true
+}
+
+locals {
+  graphdb_cluster_token = var.graphdb_cluster_token != null ? var.graphdb_cluster_token : random_password.graphdb-cluster-token[0].result
+}
+
 resource "azurerm_key_vault_secret" "graphdb-license" {
   key_vault_id = data.azurerm_key_vault.graphdb.id
 
@@ -17,7 +27,41 @@ resource "azurerm_key_vault_secret" "graphdb-license" {
   tags = var.tags
 }
 
+resource "azurerm_key_vault_secret" "graphdb-cluster-token" {
+  count = var.graphdb_java_options != null ? 1 : 0
+
+  key_vault_id = data.azurerm_key_vault.graphdb.id
+
+  name  = var.graphdb_cluster_token_name
+  value = base64encode(local.graphdb_cluster_token)
+
+  tags = var.tags
+}
+
+resource "azurerm_key_vault_secret" "graphdb-properties" {
+  count = var.graphdb_properties_path != null ? 1 : 0
+
+  key_vault_id = data.azurerm_key_vault.graphdb.id
+
+  name  = var.graphdb_properties_secret_name
+  value = filebase64(var.graphdb_properties_path)
+
+  tags = var.tags
+}
+
+resource "azurerm_key_vault_secret" "graphdb-java-options" {
+  count = var.graphdb_java_options != null ? 1 : 0
+
+  key_vault_id = data.azurerm_key_vault.graphdb.id
+
+  name  = var.graphdb_java_options_secret_name
+  value = base64encode(var.graphdb_java_options)
+
+  tags = var.tags
+}
+
 # TODO: Cannot assign the secret resource as scope for some reason... it doesn't show in the console and it does not work in the VMs
+# TODO: Not the right place for this to be here if we cannot give more granular access
 
 # Give rights to the provided identity to be able to read it from the vault
 resource "azurerm_role_assignment" "graphdb-license-reader" {

--- a/modules/configuration/variables.tf
+++ b/modules/configuration/variables.tf
@@ -11,7 +11,7 @@ variable "resource_group_name" {
   type        = string
 }
 
-# Dependencies
+# Security dependencies
 
 variable "identity_name" {
   description = "Name of a user assigned identity for assigning permissions"
@@ -34,4 +34,40 @@ variable "graphdb_license_secret_name" {
   description = "Name of the Key Vault secret that contains the GraphDB license."
   type        = string
   default     = "graphdb-license"
+}
+
+variable "graphdb_cluster_token" {
+  description = "Secret token used to secure the internal GraphDB cluster communication."
+  type        = string
+  default     = null
+}
+
+variable "graphdb_cluster_token_name" {
+  description = "Name of the Key Vault secret that contains the GraphDB cluster secret token."
+  type        = string
+  default     = "graphdb-cluster-token"
+}
+
+variable "graphdb_properties_path" {
+  description = "Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM."
+  type        = string
+  default     = null
+}
+
+variable "graphdb_properties_secret_name" {
+  description = "Name of the Key Vault secret that contains the GraphDB properties."
+  type        = string
+  default     = "graphdb-properties"
+}
+
+variable "graphdb_java_options" {
+  description = "GraphDB options to pass to GraphDB with GRAPHDB_JAVA_OPTS environment variable."
+  type        = string
+  default     = null
+}
+
+variable "graphdb_java_options_secret_name" {
+  description = "Name of the Key Vault secret that contains the GraphDB GRAPHDB_JAVA_OPTS configurations."
+  type        = string
+  default     = "graphdb-java-options"
 }

--- a/modules/configuration/versions.tf
+++ b/modules/configuration/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.71.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
   }
 }

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -2,6 +2,7 @@
 
 This module provisions a scaling set of GraphDB instances. It also offers basic networking.
 The following variables should be set:
+
 * graphdb_subnets
 * instance_type
 * lb_subnets
@@ -15,13 +16,14 @@ The following variables should be set:
 * source_ssh_blocks
 
 The following external resources should be created before this module runs:
+
 * A resource group.
 * An image.
 * A virtual network with two subnets:
   * A main subnet.
   * A subnet for load balancers.
 
-TODO: At the moment, the module creates static IPs for instances in the scale set. 
+TODO: At the moment, the module creates static IPs for instances in the scale set.
 This should be changed to load balancer when the `load_balancer` module is implemented.
 
 ## How to use this module

--- a/modules/vm/templates/entrypoint.sh.tpl
+++ b/modules/vm/templates/entrypoint.sh.tpl
@@ -6,6 +6,7 @@ echo "Configuring GraphDB instance"
 
 systemctl stop graphdb
 
+# TODO: If GraphDB is behind closed network, this would break the whole initialization...
 until ping -c 1 google.com &> /dev/null; do
   echo "waiting for outbound connectivity"
   sleep 5
@@ -28,11 +29,13 @@ node_dns=$(hostname)
 # GraphDB configuration overrides
 #
 
+secrets=$(az keyvault secret list --vault-name ${key_vault_name} --output json | jq .[].name)
+
 # Get the license
 az keyvault secret download --vault-name ${key_vault_name} --name graphdb-license --file /etc/graphdb/graphdb.license --encoding base64
 
-# TODO: Should come from app config or be randomly generated
-graphdb_cluster_token="xxxxxxxxxxxx"
+# Get the cluster token
+graphdb_cluster_token=$(az keyvault secret show --vault-name ${key_vault_name} --name graphdb-cluster-token | jq -rj .value | base64 -d)
 
 # TODO: where is the vhost here?
 cat << EOF > /etc/graphdb/graphdb.properties
@@ -50,6 +53,25 @@ graphdb.vhosts=http://${load_balancer_fqdn},http://$${node_dns}:7201
 graphdb.rpc.address=$${node_dns}:7301
 graphdb.proxy.hosts=$${node_dns}:7300
 EOF
+
+# TODO: overrides for the proxy?
+# Appends configuration overrides to graphdb.properties
+if [[ $secrets == *"graphdb-properties"* ]]; then
+  echo "Using graphdb.properties overrides"
+  az keyvault secret show --vault-name ${key_vault_name} --name graphdb-properties | jq -rj .value | base64 -d >> /etc/graphdb/graphdb.properties
+fi
+
+# Appends environment overrides to GDB_JAVA_OPTS
+if [[ $secrets == *"graphdb-java-options"* ]]; then
+  echo "Using GDB_JAVA_OPTS overrides"
+  extra_graphdb_java_options=$(az keyvault secret show --vault-name ${key_vault_name} --name graphdb-java-options | jq -rj .value | base64 -d)
+  (
+    source /etc/graphdb/graphdb.env
+    echo "GDB_JAVA_OPTS=$GDB_JAVA_OPTS $extra_graphdb_java_options" >> /etc/graphdb/graphdb.env
+  )
+fi
+
+# TODO: -Xmx based on the machine's memory size
 
 # TODO: Backup cron
 

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "graphdb_subnet_address_prefix" {
 variable "graphdb_version" {
   description = "GraphDB version to deploy"
   type        = string
-  default     = "10.4.0"
+  default     = "10.4.1"
 }
 
 variable "graphdb_image_id" {
@@ -61,6 +61,24 @@ variable "graphdb_image_id" {
 variable "graphdb_license_path" {
   description = "Local path to a file, containing a GraphDB Enterprise license."
   type        = string
+}
+
+variable "graphdb_cluster_token" {
+  description = "Secret token used to secure the internal GraphDB cluster communication. Will generate one if left undeclared."
+  type        = string
+  default     = null
+}
+
+variable "graphdb_properties_path" {
+  description = "Path to a local file containing GraphDB properties (graphdb.properties) that would be appended to the default in the VM."
+  type        = string
+  default     = null
+}
+
+variable "graphdb_java_options" {
+  description = "GraphDB options to pass to GraphDB with GRAPHDB_JAVA_OPTS environment variable."
+  type        = string
+  default     = null
 }
 
 # GraphDB VM


### PR DESCRIPTION
## Changes

- Added optional cluster token configuration (if empty, it generates a random secret)
- Added insertion of additional optional graphdb.properties configurations
- Added optional GraphDB environment variables configurations
