### PR TITLE
TES-358: Added Key Vault NACLs

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -1,6 +1,27 @@
+resource "random_string" "storage_account_name_suffix" {
+  length  = 6
+  lower   = true
+  numeric = false
+  special = false
+  upper   = false
+}
+
+locals {
+  # Storage account names have very specific naming restrictions
+
+  # Remove all non alphanumeric characters
+  sanitized = replace(var.resource_name_prefix, "/[^a-zA-Z0-9]/", "")
+
+  # Trim down to 18 characters to allow the random suffix of 6
+  trimmed = lower(substr(local.sanitized, 0, 18))
+
+  # Create storage account name with unique suffix
+  storage_account_name = "${local.trimmed}${random_string.storage_account_name_suffix.result}"
+}
+
 # Create an Azure Storage Account for backups
-resource "azurerm_storage_account" "backup" {
-  name                      = "${var.resource_name_prefix}2graphdbbackup"
+resource "azurerm_storage_account" "graphdb-backup" {
+  name                      = local.storage_account_name
   resource_group_name       = var.resource_group_name
   location                  = var.location
   account_tier              = var.storage_account_tier
@@ -12,28 +33,28 @@ resource "azurerm_storage_account" "backup" {
 }
 
 # Create an Azure Storage container
-resource "azurerm_storage_container" "backup" {
+resource "azurerm_storage_container" "graphdb-backup" {
   name                  = "${var.resource_name_prefix}-backup"
-  storage_account_name  = azurerm_storage_account.backup.name
+  storage_account_name  = azurerm_storage_account.graphdb-backup.name
   container_access_type = "private"
 }
 
 # Create an Azure Storage blob
-resource "azurerm_storage_blob" "backup" {
+resource "azurerm_storage_blob" "graphdb-backup" {
   name                   = "${var.resource_name_prefix}-backup"
   type                   = "Block"
-  storage_account_name   = azurerm_storage_account.backup.name
-  storage_container_name = azurerm_storage_container.backup.name
+  storage_account_name   = azurerm_storage_account.graphdb-backup.name
+  storage_container_name = azurerm_storage_container.graphdb-backup.name
 }
 
-resource "azurerm_role_assignment" "backup" {
+resource "azurerm_role_assignment" "graphdb-backup" {
   principal_id         = var.identity_principal_id
   role_definition_name = "Storage Blob Data Contributor"
-  scope                = azurerm_storage_account.backup.id
+  scope                = azurerm_storage_account.graphdb-backup.id
 }
 
-resource "azurerm_storage_management_policy" "retention" {
-  storage_account_id = azurerm_storage_account.backup.id
+resource "azurerm_storage_management_policy" "graphdb-backup-retention" {
+  storage_account_id = azurerm_storage_account.graphdb-backup.id
 
   rule {
     enabled = true

--- a/modules/backup/outputs.tf
+++ b/modules/backup/outputs.tf
@@ -1,8 +1,9 @@
 output "storage_account_name" {
   description = "Storage account name for storing GraphDB backups"
-  value       = azurerm_storage_account.backup.name
+  value       = azurerm_storage_account.graphdb-backup.name
 }
 
 output "container_name" {
-  value = azurerm_storage_container.backup.name
+  description = "Name of the storage container for GraphDB backups"
+  value       = azurerm_storage_container.graphdb-backup.name
 }

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -1,12 +1,39 @@
+# Common configurations
+
 variable "resource_name_prefix" {
   description = "Resource name prefix used for tagging and naming Azure resources"
   type        = string
+}
+
+variable "location" {
+  description = "Azure geographical location where resources will be deployed"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common resource tags."
+  type        = map(string)
+  default     = {}
 }
 
 variable "resource_group_name" {
   description = "Specifies the name of the Azure resource group in which the Azure Storage Account will be created"
   type        = string
 }
+
+# Identity
+
+variable "identity_name" {
+  description = "Name of a user assigned identity for assigning permissions"
+  type        = string
+}
+
+variable "identity_principal_id" {
+  description = "Principal identifier of a user assigned identity for assigning permissions"
+  type        = string
+}
+
+# Storage specifics
 
 variable "storage_account_tier" {
   default     = "Standard"
@@ -17,25 +44,4 @@ variable "storage_account_tier" {
 variable "storage_account_replication_type" {
   default     = "LRS"
   description = "Specify the data redundancy strategy for your Azure Storage Account"
-}
-
-variable "tags" {
-  description = "Common resource tags."
-  type        = map(string)
-  default     = {}
-}
-
-variable "identity_name" {
-  description = "Name of a user assigned identity for assigning permissions"
-  type        = string
-}
-
-variable "location" {
-  description = "Azure geographical location where resources will be deployed"
-  type        = string
-}
-
-variable "identity_principal_id" {
-  description = "Principal identifier of a user assigned identity for assigning permissions"
-  type        = string
 }

--- a/modules/configuration/main.tf
+++ b/modules/configuration/main.tf
@@ -35,8 +35,8 @@ resource "azurerm_key_vault_secret" "graphdb-cluster-token" {
 resource "azurerm_key_vault_secret" "graphdb-password" {
   key_vault_id = var.key_vault_id
 
-  name  = var.graphdb_cluster_token_name
-  value = base64encode(local.graphdb_cluster_token)
+  name  = var.graphdb_password_secret_name
+  value = base64encode(local.graphdb_password)
 
   tags = var.tags
 }

--- a/modules/configuration/variables.tf
+++ b/modules/configuration/variables.tf
@@ -37,16 +37,22 @@ variable "graphdb_cluster_token" {
   default     = null
 }
 
-variable "graphdb_password" {
-  description = "Secret token used to access GraphDB cluster."
-  type        = string
-  default     = null
-}
-
 variable "graphdb_cluster_token_name" {
   description = "Name of the Key Vault secret that contains the GraphDB cluster secret token."
   type        = string
   default     = "graphdb-cluster-token"
+}
+
+variable "graphdb_password" {
+  description = "Administrator credentials for accessing GraphDB"
+  type        = string
+  default     = null
+}
+
+variable "graphdb_password_secret_name" {
+  description = "Name of the Key Vault secret that contains the GraphDB administrator credentials"
+  type        = string
+  default     = "graphdb-password"
 }
 
 variable "graphdb_properties_path" {

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -13,7 +13,6 @@ locals {
   vault_name = "${var.resource_name_prefix}-${random_string.vault_name_suffix.result}"
 }
 
-# TODO: Improve the security of the vault (non-public + nacl + network firewall)
 resource "azurerm_key_vault" "graphdb" {
   name                = local.vault_name
   resource_group_name = var.resource_group_name
@@ -22,6 +21,13 @@ resource "azurerm_key_vault" "graphdb" {
 
   sku_name                  = "standard"
   enable_rbac_authorization = true
+
+  network_acls {
+    bypass                     = "AzureServices"
+    default_action             = "Deny"
+    virtual_network_subnet_ids = var.nacl_subnet_ids
+    ip_rules                   = var.nacl_ip_rules
+  }
 
   tags = var.tags
 }

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -1,3 +1,5 @@
+# Common configurations
+
 variable "resource_name_prefix" {
   description = "Resource name prefix used for tagging and naming Azure resources"
   type        = string
@@ -17,4 +19,18 @@ variable "tags" {
 variable "resource_group_name" {
   description = "Name of the resource group where GraphDB will be deployed."
   type        = string
+}
+
+# Networking
+
+variable "nacl_subnet_ids" {
+  description = "List of subnet identifiers allowed to access the key vault internally over a service link"
+  type        = list(string)
+  default     = []
+}
+
+variable "nacl_ip_rules" {
+  description = "List of CIDR blocks allowed to access the key vault from the internet"
+  type        = list(string)
+  default     = []
 }

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -86,7 +86,7 @@ resource "azurerm_monitor_autoscale_setting" "graphdb-autoscale-settings" {
 }
 
 resource "azurerm_role_definition" "managed_disk_manager" {
-  name        = "ManagedDiskManager"
+  name        = "${var.resource_name_prefix}-ManagedDiskManager"
   scope       = var.resource_group_id
   description = "This is a custom role created via Terraform required for creating data disks for GraphDB"
 
@@ -112,12 +112,12 @@ resource "azurerm_role_definition" "managed_disk_manager" {
 resource "azurerm_role_assignment" "rg-contributor-role" {
   principal_id         = var.identity_principal_id
   scope                = var.resource_group_id
-  role_definition_name = "ManagedDiskManager"
+  role_definition_name = "${var.resource_name_prefix}-ManagedDiskManager"
   depends_on           = [azurerm_role_definition.managed_disk_manager]
 }
 
 resource "azurerm_role_definition" "backup_role" {
-  name        = "ReadOnlyVMSSStorageRole"
+  name        = "${var.resource_name_prefix}-ReadOnlyVMSSStorageRole"
   scope       = var.resource_group_id
   description = "This is a custom role created via Terraform required for creating backups in GraphDB"
 
@@ -137,7 +137,7 @@ resource "azurerm_role_definition" "backup_role" {
 resource "azurerm_role_assignment" "rg-reader-role" {
   principal_id         = var.identity_principal_id
   scope                = var.resource_group_id
-  role_definition_name = "ReadOnlyVMSSStorageRole"
+  role_definition_name = "${var.resource_name_prefix}-ReadOnlyVMSSStorageRole"
   depends_on           = [azurerm_role_definition.backup_role]
 }
 


### PR DESCRIPTION
## Changes

- Added key vault service endpoints to the gateway and vmss subnets
- Configured the key vault with NACLs to restrict the access only to the virtual network and given management CIDRs
- Fixed the graphdb password configuration secret to reference the correct value
- Organized the backup module
- Added the resource name prefix to the custom roles to avoid clashes