### PR TITLE
TES-359: Fine tune role assignments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           format: sarif
           output: trivy.sarif
 
-      - name: Upload SARIF file
+      - name: Upload Trivy SARIF results
         uses: github/codeql-action/upload-sarif@v2
         timeout-minutes: 1
         with:

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -48,20 +48,6 @@ resource "azurerm_storage_container" "graphdb-backup" {
   container_access_type = "private"
 }
 
-# Create an Azure Storage blob
-resource "azurerm_storage_blob" "graphdb-backup" {
-  name                   = "${var.resource_name_prefix}-backup"
-  type                   = "Block"
-  storage_account_name   = azurerm_storage_account.graphdb-backup.name
-  storage_container_name = azurerm_storage_container.graphdb-backup.name
-}
-
-resource "azurerm_role_assignment" "graphdb-backup" {
-  principal_id         = var.identity_principal_id
-  role_definition_name = "Storage Blob Data Contributor"
-  scope                = azurerm_storage_account.graphdb-backup.id
-}
-
 resource "azurerm_storage_management_policy" "graphdb-backup-retention" {
   storage_account_id = azurerm_storage_account.graphdb-backup.id
 

--- a/modules/backup/outputs.tf
+++ b/modules/backup/outputs.tf
@@ -1,9 +1,19 @@
+output "storage_account_id" {
+  description = "Storage account identifier for storing GraphDB backups"
+  value       = azurerm_storage_account.graphdb-backup.id
+}
+
 output "storage_account_name" {
   description = "Storage account name for storing GraphDB backups"
   value       = azurerm_storage_account.graphdb-backup.name
 }
 
-output "container_name" {
+output "storage_container_id" {
+  description = "Identifier of the storage container for GraphDB backups"
+  value       = azurerm_storage_container.graphdb-backup.id
+}
+
+output "storage_container_name" {
   description = "Name of the storage container for GraphDB backups"
   value       = azurerm_storage_container.graphdb-backup.name
 }

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -35,13 +35,6 @@ variable "nacl_ip_rules" {
   default     = []
 }
 
-# Identity
-
-variable "identity_principal_id" {
-  description = "Principal identifier of a user assigned identity for assigning permissions"
-  type        = string
-}
-
 # Storage specifics
 
 variable "storage_account_tier" {

--- a/modules/configuration/main.tf
+++ b/modules/configuration/main.tf
@@ -68,19 +68,34 @@ resource "azurerm_key_vault_secret" "graphdb-java-options" {
   tags = var.tags
 }
 
-# TODO: Cannot assign the secret resource as scope for some reason... it doesn't show in the console and it does not work in the VMs
-# TODO: Not the right place for this to be here if we cannot give more granular access
-
-# Give rights to the provided identity to be able to read it from the vault
-resource "azurerm_role_assignment" "graphdb-license-reader" {
-  principal_id         = var.identity_principal_id
-  scope                = var.key_vault_id
-  role_definition_name = "Key Vault Reader"
-}
-
-# Give rights to the provided identity to actually get the secret value
 resource "azurerm_role_assignment" "graphdb-license-secret-reader" {
   principal_id         = var.identity_principal_id
-  scope                = var.key_vault_id
+  scope                = azurerm_key_vault_secret.graphdb-license.resource_versionless_id
+  role_definition_name = "Key Vault Secrets User"
+}
+
+resource "azurerm_role_assignment" "graphdb-cluster-token-secret-reader" {
+  principal_id         = var.identity_principal_id
+  scope                = azurerm_key_vault_secret.graphdb-cluster-token.resource_versionless_id
+  role_definition_name = "Key Vault Secrets User"
+}
+
+resource "azurerm_role_assignment" "graphdb-java-options-secret-reader" {
+  count                = var.graphdb_java_options != null ? 1 : 0
+  principal_id         = var.identity_principal_id
+  scope                = azurerm_key_vault_secret.graphdb-java-options[0].resource_versionless_id
+  role_definition_name = "Key Vault Secrets User"
+}
+
+resource "azurerm_role_assignment" "graphdb-password-secret-reader" {
+  principal_id         = var.identity_principal_id
+  scope                = azurerm_key_vault_secret.graphdb-password.resource_versionless_id
+  role_definition_name = "Key Vault Secrets User"
+}
+
+resource "azurerm_role_assignment" "graphdb-properties-secret-reader" {
+  count                = var.graphdb_properties_path != null ? 1 : 0
+  principal_id         = var.identity_principal_id
+  scope                = azurerm_key_vault_secret.graphdb-properties[0].resource_versionless_id
   role_definition_name = "Key Vault Secrets User"
 }

--- a/modules/identity/variables.tf
+++ b/modules/identity/variables.tf
@@ -1,3 +1,5 @@
+# General configurations
+
 variable "resource_name_prefix" {
   description = "Resource name prefix used for tagging and naming Azure resources"
   type        = string

--- a/modules/roles/README.md
+++ b/modules/roles/README.md
@@ -1,0 +1,1 @@
+# GraphDB Roles Module

--- a/modules/roles/main.tf
+++ b/modules/roles/main.tf
@@ -1,0 +1,45 @@
+# Assign the identity to have read access to the key vault
+resource "azurerm_role_assignment" "graphdb-vmss-key-vault-reader" {
+  principal_id         = var.identity_principal_id
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Reader"
+}
+
+# Assign the identity to be able to upload GraphDB backups in the storage BLOB
+resource "azurerm_role_assignment" "graphdb-backup" {
+  principal_id         = var.identity_principal_id
+  scope                = var.backups_storage_container_id
+  role_definition_name = "Storage Blob Data Contributor"
+}
+
+resource "azurerm_role_definition" "managed_disk_manager" {
+  name        = "${var.resource_name_prefix}-ManagedDiskManager"
+  scope       = var.resource_group_id
+  description = "This is a custom role created via Terraform required for creating data disks for GraphDB"
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/disks/write",
+      "Microsoft.Compute/virtualMachineScaleSets/read",
+      "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write",
+      "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+      "Microsoft.Network/virtualNetworks/subnets/join/action",
+      "Microsoft.Network/applicationGateways/backendAddressPools/join/action",
+      "Microsoft.Network/networkSecurityGroups/join/action"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    var.resource_group_id
+  ]
+}
+
+resource "azurerm_role_assignment" "rg-contributor-role" {
+  principal_id         = var.identity_principal_id
+  scope                = var.resource_group_id
+  role_definition_name = azurerm_role_definition.managed_disk_manager.name
+
+  depends_on = [azurerm_role_definition.managed_disk_manager]
+}

--- a/modules/roles/variables.tf
+++ b/modules/roles/variables.tf
@@ -1,0 +1,32 @@
+# Common configurations
+
+variable "resource_name_prefix" {
+  description = "Resource name prefix used for tagging and naming Azure resources"
+  type        = string
+}
+
+variable "resource_group_id" {
+  description = "Identifier of the resource group where GraphDB will be deployed."
+  type        = string
+}
+
+# Identity
+
+variable "identity_principal_id" {
+  description = "Principal identifier of a user assigned identity for assigning permissions"
+  type        = string
+}
+
+# Key Vault
+
+variable "key_vault_id" {
+  description = "Identifier of a Key Vault for storing GraphDB configurations"
+  type        = string
+}
+
+# Backups storage
+
+variable "backups_storage_container_id" {
+  description = "Identifier of the storage container for GraphDB backups"
+  type        = string
+}

--- a/modules/tls/main.tf
+++ b/modules/tls/main.tf
@@ -6,9 +6,8 @@ resource "azurerm_user_assigned_identity" "graphdb-tls-certificate" {
   tags = var.tags
 }
 
-# TODO: probably have to add Key Vault Reader as well
-
-resource "azurerm_role_assignment" "graphdb-tls-certificate-reader" {
+# Azure AG requires this role to the be assigned to the Key Vault directly
+resource "azurerm_role_assignment" "graphdb-tls-key-vault-secrets-reader" {
   principal_id         = azurerm_user_assigned_identity.graphdb-tls-certificate.principal_id
   scope                = var.key_vault_id
   role_definition_name = "Key Vault Secrets User"

--- a/modules/vm/templates/entrypoint.sh.tpl
+++ b/modules/vm/templates/entrypoint.sh.tpl
@@ -207,9 +207,7 @@ fi
 
 BACKUP_NAME="\$(date +'%Y-%m-%d_%H-%M-%S').tar"
 TEMP_BACKUP_DIR="/var/opt/graphdb/"
-STORAGE_ACCOUNT="\$(az storage account list --resource-group "\$RESOURCE_GROUP" --query "[].name" --output tsv)"
-CONTAINER_NAME="\$(az storage container list --account-name "\$STORAGE_ACCOUNT" --query "[].name" --output tsv --auth-mode login)"
-BLOB_URL="\$(az storage blob url --account-name "\$STORAGE_ACCOUNT" --container-name "\$CONTAINER_NAME" --name "\$BACKUP_NAME" --auth-mode login --output tsv)"
+BLOB_URL="${backup_storage_container_url}/\$${BACKUP_NAME}"
 
 function trigger_backup {
   curl -X POST --output "\$${TEMP_BACKUP_DIR}\$${BACKUP_NAME}" -H 'Content-Type: application/json' 'http://localhost:7200/rest/recovery/backup'

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -27,11 +27,6 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "resource_group_id" {
-  description = "Identifier of the resource group where GraphDB will be deployed."
-  type        = string
-}
-
 # Networking
 
 variable "graphdb_subnet_id" {
@@ -43,11 +38,6 @@ variable "graphdb_subnet_id" {
 
 variable "identity_id" {
   description = "Identifier of a user assigned identity with permissions"
-  type        = string
-}
-
-variable "identity_principal_id" {
-  description = "Principal identifier of a user assigned identity with permissions"
   type        = string
 }
 
@@ -125,6 +115,13 @@ variable "disk_mbps_read_write" {
   description = "Data disk throughput"
   type        = number
   default     = null
+}
+
+# Backups
+
+variable "backup_storage_container_url" {
+  description = "URL to a storage container for uploading GraphDB backups"
+  type        = string
 }
 
 variable "backup_schedule" {


### PR DESCRIPTION
TES-359: Role assignments overhaul

The overhaul focuses on simplifying the module dependencies and responsibilities.

- Vault and backup modules no longer depend on an identity
- Added a new module rules dedicated for role assignments to anything required by the VMSS such as the key vault and backup storage account
- Moved custom roles to the new roles module
- Removed the storage account custom role in favor of directly providing the storage container in the user data script
- Removed useless empty BLOB creation in the storage account
- Optimized configurations role assignments for least privilege
- Updated some comments/descriptions

