### PR TITLE
TES-432: Use service principle for KV and App Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ options.
 | key\_vault\_retention\_days | Retention period in days during which soft deleted secrets are kept | `number` | `30` | no |
 | app\_config\_enable\_purge\_protection | Prevents purging the App Configuration and its keys by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `false` | no |
 | app\_config\_retention\_days | Retention period in days during which soft deleted keys are kept | `number` | `7` | no |
-| assign\_data\_owner\_roles | Enables the assignment of data owner or administrator roles for the current user in services requiring such role for inserting data during Terraform apply, i.e. KeyVault and AppConfig. | `bool` | `true` | no |
+| admin\_security\_principle\_id | UUID of a user or service principle that will become data owner or administrator for specific resources that need permissions to insert data during Terraform apply, i.e. KeyVault and AppConfig. If left unspecified, the current user will be used. | `string` | `null` | no |
 | graphdb\_version | GraphDB version to deploy. | `string` | `"10.5.0"` | no |
 | graphdb\_image\_gallery | Identifier of the public compute image gallery from which GraphDB VM images can be pulled. | `string` | `"GraphDB-02faf3ce-79ed-4676-ab69-0e422bbd9ee1"` | no |
 | graphdb\_image\_version | Version of the GraphDB VM image to deploy. | `string` | `"latest"` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,14 @@
 # COMMON RESOURCES AND NETWORKING -------------------------------
 
+data "azurerm_client_config" "current" {}
+
 locals {
   tags = merge({
     # Used to easily track all resource managed by Terraform
     Source     = "Terraform"
     Deployment = var.resource_name_prefix
   }, var.tags)
+  admin_security_principle_id = var.admin_security_principle_id != null ? var.admin_security_principle_id : data.azurerm_client_config.current.object_id
 }
 
 resource "azurerm_resource_group" "graphdb" {
@@ -127,8 +130,8 @@ module "vault" {
   key_vault_enable_purge_protection = var.key_vault_enable_purge_protection
   key_vault_retention_days          = var.key_vault_retention_days
 
-  assign_administrator_role = var.assign_data_owner_roles
-  storage_account_id        = module.backup.storage_account_id
+  admin_security_principle_id = local.admin_security_principle_id
+  storage_account_id          = module.backup.storage_account_id
 }
 
 # Creates a Storage Account for storing GraphDB backups
@@ -167,7 +170,7 @@ module "appconfig" {
   app_config_enable_purge_protection = var.app_config_enable_purge_protection
   app_config_retention_days          = var.app_config_retention_days
 
-  assign_owner_role = var.assign_data_owner_roles
+  admin_security_principle_id = local.admin_security_principle_id
 }
 
 # Creates GraphDB configuration key values in the App Configuration store

--- a/modules/appconfig/main.tf
+++ b/modules/appconfig/main.tf
@@ -25,14 +25,8 @@ resource "azurerm_app_configuration" "graphdb" {
   soft_delete_retention_days = var.app_config_retention_days
 }
 
-data "azurerm_client_config" "current" {
-}
-
-# Assigns Data Owner to the current user executing the data scripts. Needed in order to be able to create configuration keys later.
 resource "azurerm_role_assignment" "app_config_data_owner" {
-  count = var.assign_owner_role ? 1 : 0
-
-  principal_id         = data.azurerm_client_config.current.object_id
+  principal_id         = var.admin_security_principle_id
   scope                = azurerm_app_configuration.graphdb.id
   role_definition_name = "App Configuration Data Owner"
 }

--- a/modules/appconfig/variables.tf
+++ b/modules/appconfig/variables.tf
@@ -32,8 +32,8 @@ variable "app_config_retention_days" {
 
 # Role assigment
 
-variable "assign_owner_role" {
-  description = "Assign 'App Configuration Data Owner' role to the current client. Needed in order to create keys."
-  type        = bool
-  default     = true
+variable "admin_security_principle_id" {
+  description = "UUID of a user or service principle that will become App Configuration data owner"
+  type        = string
+  default     = null
 }

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -33,11 +33,8 @@ resource "azurerm_key_vault" "graphdb" {
   }
 }
 
-# Add vault data permissions to the current client that is executing this Terraform script
 resource "azurerm_role_assignment" "graphdb_key_vault_manager" {
-  count = var.assign_administrator_role ? 1 : 0
-
-  principal_id         = data.azurerm_client_config.current.object_id
+  principal_id         = var.admin_security_principle_id
   scope                = azurerm_key_vault.graphdb.id
   role_definition_name = "Key Vault Administrator"
 }

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -46,10 +46,10 @@ variable "key_vault_retention_days" {
 
 # Role assigment
 
-variable "assign_administrator_role" {
-  description = "Assign 'Key Vault Administrator' role to the current client. Needed in order to create secrets."
-  type        = bool
-  default     = true
+variable "admin_security_principle_id" {
+  description = "UUID of a user or service principle that will become Key Vault administrator"
+  type        = string
+  default     = null
 }
 
 # Storage account

--- a/variables.tf
+++ b/variables.tf
@@ -111,10 +111,10 @@ variable "app_config_retention_days" {
 
 # Role Assignments
 
-variable "assign_data_owner_roles" {
-  description = "Enables the assignment of data owner or administrator roles for the current user in services requiring such role for inserting data during Terraform apply, i.e. KeyVault and AppConfig."
-  type        = bool
-  default     = true
+variable "admin_security_principle_id" {
+  description = "UUID of a user or service principle that will become data owner or administrator for specific resources that need permissions to insert data during Terraform apply, i.e. KeyVault and AppConfig. If left unspecified, the current user will be used."
+  type        = string
+  default     = null
 }
 
 # GraphDB VM image configuration


### PR DESCRIPTION
## Changes

Instead of assigning the current user as data owner or administrator, it's better to assign a security group.

- Added optional configuration `admin_security_principle_id`
- Removed `assign_data_owner_roles` configuration
- Reverted wrongly reverted empty file
