### PR TITLE
TES-461: Switch to Marketplace offer as image source

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,19 @@ See https://github.com/hashicorp/terraform-aws-consul
 You then need to authenticate in your subscription with Azure CLI,
 see [Authenticating using the Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli) for more details.
 
-Additional steps include
+Additional steps include:
 
 - Enable [VM Encryption At Host](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disks-enable-host-based-encryption-cli)
 - Register AppConfiguration with `az provider register --namespace "Microsoft.AppConfiguration"`
 - Register AllowApplicationGatewayPrivateLink with `az feature register --name AllowApplicationGatewayPrivateLink --namespace Microsoft.Network` if 
   you are planning on using Private Link
+
+The Terraform module deploys a VM scale set based on a VM image published in the Azure Marketplace. 
+This requires you to accept the terms which can be accomplished with Azure CLI:
+
+```bash
+az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher ontotextad1692361256062
+```
 
 <!-- BEGIN_TF_DOCS -->
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -110,11 +110,9 @@ az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher onto
 | app\_config\_enable\_purge\_protection | Prevents purging the App Configuration and its keys by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `false` | no |
 | app\_config\_retention\_days | Retention period in days during which soft deleted keys are kept | `number` | `7` | no |
 | admin\_security\_principle\_id | UUID of a user or service principle that will become data owner or administrator for specific resources that need permissions to insert data during Terraform apply, i.e. KeyVault and AppConfig. If left unspecified, the current user will be used. | `string` | `null` | no |
-| graphdb\_version | GraphDB version to deploy. | `string` | `"10.5.0"` | no |
-| graphdb\_image\_gallery | Identifier of the public compute image gallery from which GraphDB VM images can be pulled. | `string` | `"GraphDB-02faf3ce-79ed-4676-ab69-0e422bbd9ee1"` | no |
-| graphdb\_image\_version | Version of the GraphDB VM image to deploy. | `string` | `"latest"` | no |
-| graphdb\_image\_architecture | Architecture of the GraphDB VM image. | `string` | `"x86_64"` | no |
-| graphdb\_image\_id | Full image identifier to use for running GraphDB VM instances. If left unspecified, Terraform will use the image from our public Compute Gallery. | `string` | `null` | no |
+| graphdb\_version | GraphDB version from the marketplace offer | `string` | `"10.6.0"` | no |
+| graphdb\_sku | GraphDB SKU from the marketplace offer | `string` | `"graphdb-byol"` | no |
+| graphdb\_image\_id | GraphDB image ID to use for the scale set VM instances in place of the default marketplace offer | `string` | `null` | no |
 | graphdb\_license\_path | Local path to a file, containing a GraphDB Enterprise license. | `string` | n/a | yes |
 | graphdb\_cluster\_token | Secret token used to secure the internal GraphDB cluster communication. Will generate one if left undeclared. | `string` | `null` | no |
 | graphdb\_password | Secret token used to access GraphDB cluster. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -165,11 +165,6 @@ module "bastion" {
   bastion_allowed_inbound_address_prefixes = var.management_cidr_blocks
 }
 
-locals {
-  graphdb_gallery_image_id = "/communityGalleries/${var.graphdb_image_gallery}/images/${var.graphdb_version}-${var.graphdb_image_architecture}/versions/${var.graphdb_image_version}"
-  graphdb_image_id         = var.graphdb_image_id != null ? var.graphdb_image_id : local.graphdb_gallery_image_id
-}
-
 # Configures Azure monitoring
 module "monitoring" {
   count = var.deploy_monitoring ? 1 : 0
@@ -237,9 +232,13 @@ module "graphdb" {
   backup_storage_container_name = module.backup.storage_container_name
   backup_schedule               = var.backup_schedule
 
+  # VM Image
+  graphdb_sku      = var.graphdb_sku
+  graphdb_version  = var.graphdb_version
+  graphdb_image_id = var.graphdb_image_id
+
   # VMSS
   instance_type = var.instance_type
-  image_id      = local.graphdb_image_id
   node_count    = var.node_count
   ssh_key       = var.ssh_key
 

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -177,6 +177,24 @@ variable "graphdb_java_options_secret_name" {
   default     = "graphdb-java-options"
 }
 
+# GraphDB VM image configuration
+
+variable "graphdb_version" {
+  description = "GraphDB version from the marketplace offer"
+  type        = string
+}
+
+variable "graphdb_sku" {
+  description = "GraphDB SKU from the marketplace offer"
+  type        = string
+}
+
+variable "graphdb_image_id" {
+  description = "GraphDB image ID to use for the scale set VM instances in place of the default marketplace offer"
+  type        = string
+  default     = null
+}
+
 # GraphDB VM
 
 variable "node_count" {
@@ -187,11 +205,6 @@ variable "node_count" {
 
 variable "instance_type" {
   description = "Azure instance type"
-  type        = string
-}
-
-variable "image_id" {
-  description = "Image ID to use with GraphDB instances"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -173,31 +173,19 @@ variable "admin_security_principle_id" {
 # GraphDB VM image configuration
 
 variable "graphdb_version" {
-  description = "GraphDB version to deploy."
+  description = "GraphDB version from the marketplace offer"
   type        = string
-  default     = "10.5.0"
+  default     = "10.6.0"
 }
 
-variable "graphdb_image_gallery" {
-  description = "Identifier of the public compute image gallery from which GraphDB VM images can be pulled."
+variable "graphdb_sku" {
+  description = "GraphDB SKU from the marketplace offer"
   type        = string
-  default     = "GraphDB-02faf3ce-79ed-4676-ab69-0e422bbd9ee1"
-}
-
-variable "graphdb_image_version" {
-  description = "Version of the GraphDB VM image to deploy."
-  type        = string
-  default     = "latest"
-}
-
-variable "graphdb_image_architecture" {
-  description = "Architecture of the GraphDB VM image."
-  type        = string
-  default     = "x86_64"
+  default     = "graphdb-byol"
 }
 
 variable "graphdb_image_id" {
-  description = "Full image identifier to use for running GraphDB VM instances. If left unspecified, Terraform will use the image from our public Compute Gallery."
+  description = "GraphDB image ID to use for the scale set VM instances in place of the default marketplace offer"
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Changes

It's easier to reference GraphDB from the marketplace without building any resource ID, and it makes more sense to route it through there so users can accept the terms.

Additionally:
- Updated to GraphDB 10.6.0