### PR TITLE
Add option for TLS from External Key Vault under the same tennant

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher onto
 | gateway\_enable\_private\_access | Enable or disable private access to the application gateway | `bool` | `false` | no |
 | gateway\_enable\_private\_link\_service | Set to true to enable Private Link service, false to disable it. | `bool` | `false` | no |
 | gateway\_private\_link\_service\_network\_policies\_enabled | Enable or disable private link service network policies | `string` | `false` | no |
-| tls\_certificate\_path | Path to a TLS certificate that will be imported in Azure Key Vault and used in the Application Gateway TLS listener for GraphDB. | `string` | n/a | yes |
+| tls\_certificate\_path | Path to a TLS certificate that will be imported in Azure Key Vault and used in the Application Gateway TLS listener for GraphDB. | `string` | `null` | no |
 | tls\_certificate\_password | TLS certificate password for password protected certificates. | `string` | `null` | no |
+| tls\_certificate\_id | Resource identifier for a TLS certificate secret from a Key Vault. Overrides tls\_certificate\_path | `string` | `null` | no |
+| tls\_certificate\_identity\_id | Identifier of a managed identity giving access to the TLS certificate specified with tls\_certificate\_id | `string` | `null` | no |
 | key\_vault\_enable\_purge\_protection | Prevents purging the key vault and its contents by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `false` | no |
 | key\_vault\_retention\_days | Retention period in days during which soft deleted secrets are kept | `number` | `30` | no |
 | app\_config\_enable\_purge\_protection | Prevents purging the App Configuration and its keys by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -221,6 +221,22 @@ gateway_enable_private_link_service = true
 See [Configure Azure Application Gateway Private Link](https://learn.microsoft.com/en-us/azure/application-gateway/private-link-configure?tabs=portal) 
 for further information on configuring and using Application Gateway Private Link.
 
+**Providing TLS certificate**
+
+There are two options for setting up the Application Gateway with a TLS certificate.
+
+1. Provide local certificate file in PFX format with:
+    ```hcl
+    tls_certificate_path     = "path-to-your-tls-certificate"
+    tls_certificate_password = "tls-certificate-password"     # Optional
+    ```
+   Note: This will create a dedicated Key Vault for storing the certificate.
+2. Or provide a reference to an existing TLS certificate with:
+    ```hcl
+    tls_certificate_id          = "key-vault-certificate-secret-id"
+    tls_certificate_identity_id = "managed-identity-id"
+    ```
+
 <!---
 TODO Add more examples
 -->

--- a/main.tf
+++ b/main.tf
@@ -142,8 +142,8 @@ module "application_gateway" {
   gateway_enable_private_access = var.gateway_enable_private_access
 
   # TLS
-  gateway_tls_certificate_identity_id = module.tls.tls_identity_id
-  gateway_tls_certificate_secret_id   = module.tls.tls_certificate_key_vault_secret_id
+  gateway_tls_certificate_identity_id = var.tls_manage_id != null ? var.tls_manage_id : module.tls.tls_identity_id
+  gateway_tls_certificate_secret_id   = var.tls_certificate != null ? var.tls_certificate : module.tls.tls_certificate_key_vault_secret_id
 
   # Private Link
   gateway_enable_private_link_service                   = var.gateway_enable_private_link_service

--- a/modules/graphdb/identity.tf
+++ b/modules/graphdb/identity.tf
@@ -8,12 +8,6 @@ resource "azurerm_user_assigned_identity" "graphdb_vmss" {
   location            = var.location
 }
 
-resource "azurerm_role_assignment" "graphdb_vmss_key_vault_reader" {
-  principal_id         = azurerm_user_assigned_identity.graphdb_vmss.principal_id
-  scope                = var.key_vault_id
-  role_definition_name = "Key Vault Reader"
-}
-
 resource "azurerm_role_assignment" "graphdb_vmss_app_config_reader" {
   principal_id         = azurerm_user_assigned_identity.graphdb_vmss.principal_id
   scope                = var.app_configuration_id

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -68,13 +68,6 @@ variable "application_gateway_backend_address_pool_ids" {
   default     = []
 }
 
-# Key Vault
-
-variable "key_vault_id" {
-  description = "Identifier of a Key Vault for storing GraphDB configurations"
-  type        = string
-}
-
 # App Configuration
 
 variable "app_configuration_id" {

--- a/modules/tls/outputs.tf
+++ b/modules/tls/outputs.tf
@@ -1,4 +1,4 @@
-output "tls_certificate_key_vault_secret_id" {
+output "tls_certificate_id" {
   description = "Secret identifier of the TLS certificate in the Key Vault"
   value       = azurerm_key_vault_certificate.graphdb_tls_certificate.secret_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,7 @@ variable "gateway_private_link_service_network_policies_enabled" {
 variable "tls_certificate_path" {
   description = "Path to a TLS certificate that will be imported in Azure Key Vault and used in the Application Gateway TLS listener for GraphDB."
   type        = string
+  default     = null
 }
 
 variable "tls_certificate_password" {
@@ -123,13 +124,14 @@ variable "tls_certificate_password" {
   default     = null
 }
 
-variable "tls_certificate" {
-  description = "TLS Certificate Secret Identifier."
+variable "tls_certificate_id" {
+  description = "Resource identifier for a TLS certificate secret from a Key Vault. Overrides tls_certificate_path"
   type        = string
+  default     = null
 }
 
-variable "tls_manage_id" {
-  description = "ID for managing TLS. If provided it will use this isntead of the one created by the Terraform Script."
+variable "tls_certificate_identity_id" {
+  description = "Identifier of a managed identity giving access to the TLS certificate specified with tls_certificate_id"
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,6 @@ variable "gateway_private_link_service_network_policies_enabled" {
 }
 
 # TLS
-
 variable "tls_certificate_path" {
   description = "Path to a TLS certificate that will be imported in Azure Key Vault and used in the Application Gateway TLS listener for GraphDB."
   type        = string
@@ -120,6 +119,17 @@ variable "tls_certificate_path" {
 
 variable "tls_certificate_password" {
   description = "TLS certificate password for password protected certificates."
+  type        = string
+  default     = null
+}
+
+variable "tls_certificate" {
+  description = "TLS Certificate Secret Identifier."
+  type        = string
+}
+
+variable "tls_manage_id" {
+  description = "ID for managing TLS. If provided it will use this isntead of the one created by the Terraform Script."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description
Add option for TLS from External Key Vault under the same tennant
<!-- Please, provide a brief description of the changes you've made in this pull request. -->
Made changes so that IF provided variables for `tls_manage_id` or/and `tls_certificate` it will use them instead of the ones created by Terraform. 
## Related Issues
TES-439
<!-- Links to related issues, fixed issues or partially addressed by this PR. -->
https://ontotext.atlassian.net/browse/TES-439
## Changes

<!-- List the main changes or features introduced by this PR -->

## Screenshots (if applicable)

<!-- Add any relevant screenshots or GIFs to showcase the changes visually -->

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
