### PR TITLE
GDB-9640 Added idle timeout variable for App GW PIP and NAT GW PIP

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 3.91.0"
   hashes = [
     "h1:FEDNnFv/uKI2+FQ+nDoyswEI3trJ3d7Fx2Cy7Ff4Rq8=",
+    "h1:LagYfbO2xfkGMMisggbfFMbVZd00ZPYnOVGig+935e0=",
     "h1:t0I5G4canK6UdlgHGfMV4rUNBPGdrMiIB01VGizlXB8=",
     "zh:13928b71b1235783f3f877a799e28fb91e50512b051eb8ccb370500fc140cf3f",
     "zh:3264341657e9ff3963d69b0fa088f64665349e2a29b2f3aeb4deee6d9d7584b7",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   constraints = "~> 2.3.3"
   hashes = [
     "h1:TCZQjXesJ9qbOZaHjJse/WyOxYQwp7wUX3VNxL/qo1c=",
+    "h1:TNvKS2y0rYHkZgb0wabYGLKAFOnDiFbvHwoXnuOF4o8=",
     "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
     "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
     "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.6.0"
   hashes = [
     "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
+    "h1:S8bSIs06Vd8C/tmrTJdRyGHH1wHz+2fTfF4+jwlylrM=",
     "h1:t0mRdJzegohRKhfdoQEJnv3JRISSezJRblN0HIe67vo=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.10.0"
   hashes = [
     "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
+    "h1:XiRMsGFEe6VTWGL0O32l8viW2fI8wXyJFRJYfdQR8os=",
     "h1:rPbqd7mEyBetQPjyBDBAdwiARulKbh2LwzQp2GSl/AI=",
     "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
     "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",

--- a/README.md
+++ b/README.md
@@ -91,11 +91,14 @@ az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher onto
 | zones | Availability zones to use for resource deployment and HA | `list(number)` | ```[ 1, 2, 3 ]``` | no |
 | tags | Common resource tags. | `map(string)` | `{}` | no |
 | lock\_resources | Enables a delete lock on the resource group to prevent accidental deletions. | `bool` | `true` | no |
+| graphdb\_external\_address\_fqdn | External FQDN address for the deployment | `string` | `null` | no |
 | virtual\_network\_address\_space | Virtual network address space CIDRs. | `list(string)` | ```[ "10.0.0.0/16" ]``` | no |
 | gateway\_subnet\_address\_prefixes | Subnet address prefixes CIDRs where the application gateway will reside. | `list(string)` | ```[ "10.0.1.0/24" ]``` | no |
 | graphdb\_subnet\_address\_prefixes | Subnet address prefixes CIDRs where GraphDB VMs will reside. | `list(string)` | ```[ "10.0.2.0/24" ]``` | no |
 | gateway\_private\_link\_subnet\_address\_prefixes | Subnet address prefixes where the Application Gateway Private Link will reside, if enabled | `list(string)` | ```[ "10.0.5.0/24" ]``` | no |
 | management\_cidr\_blocks | CIDR blocks allowed to perform management operations such as connecting to Bastion or Key Vault. | `list(string)` | n/a | yes |
+| gateway\_global\_request\_buffering\_enabled | Whether Application Gateway's Request buffer is enabled. | `bool` | `false` | no |
+| gateway\_global\_response\_buffering\_enabled | Whether Application Gateway's Response buffer is enabled. | `bool` | `false` | no |
 | inbound\_allowed\_address\_prefix | Source address prefix allowed for connecting to the application gateway | `string` | `"Internet"` | no |
 | inbound\_allowed\_address\_prefixes | Source address prefixes allowed for connecting to the application gateway. Overrides inbound\_allowed\_address\_prefix | `list(string)` | `[]` | no |
 | outbound\_allowed\_address\_prefix | Destination address prefix allowed for outbound traffic from GraphDB | `string` | `"Internet"` | no |

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ module "vault" {
   key_vault_retention_days          = var.key_vault_retention_days
 
   admin_security_principle_id = local.admin_security_principle_id
-  storage_account_id          = module.backup.storage_account_id
+  log_analytics_workspace_id  = module.monitoring[0].la_workspace_id
 }
 
 # Creates a Storage Account for storing GraphDB backups
@@ -107,6 +107,8 @@ module "appconfig" {
   app_config_retention_days          = var.app_config_retention_days
 
   admin_security_principle_id = local.admin_security_principle_id
+
+  log_analytics_workspace_id = module.monitoring[0].la_workspace_id
 }
 
 # Creates a TLS certificate secret in the Key Vault and related identity (if file is provided)

--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,10 @@ module "application_gateway" {
   gateway_private_link_subnet_address_prefixes          = var.gateway_private_link_subnet_address_prefixes
   gateway_private_link_service_network_policies_enabled = var.gateway_private_link_service_network_policies_enabled
 
+  # Global buffer settings
+  gateway_global_request_buffering_enabled  = var.gateway_global_request_buffering_enabled
+  gateway_global_response_buffering_enabled = var.gateway_global_response_buffering_enabled
+
   # Wait for role assignments
   depends_on = [module.tls]
 }

--- a/main.tf
+++ b/main.tf
@@ -227,7 +227,7 @@ module "graphdb" {
   app_configuration_name = module.appconfig.app_configuration_name
 
   # GraphDB Configurations
-  graphdb_external_address_fqdn = module.application_gateway.public_ip_address_fqdn
+  graphdb_external_address_fqdn = var.graphdb_external_address_fqdn != null ? var.graphdb_external_address_fqdn : module.application_gateway.public_ip_address_fqdn
   graphdb_password              = var.graphdb_password
   graphdb_license_path          = var.graphdb_license_path
   graphdb_cluster_token         = var.graphdb_cluster_token

--- a/modules/appconfig/main.tf
+++ b/modules/appconfig/main.tf
@@ -25,6 +25,16 @@ resource "azurerm_app_configuration" "graphdb" {
   soft_delete_retention_days = var.app_config_retention_days
 }
 
+resource "azurerm_monitor_diagnostic_setting" "application_config_diagnostic_settings" {
+  name                       = "Application Config diagnostic settings"
+  target_resource_id         = azurerm_app_configuration.graphdb.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  enabled_log {
+    category = "Audit"
+  }
+}
+
 resource "azurerm_role_assignment" "app_config_data_owner" {
   principal_id         = var.admin_security_principle_id
   scope                = azurerm_app_configuration.graphdb.id

--- a/modules/appconfig/variables.tf
+++ b/modules/appconfig/variables.tf
@@ -37,3 +37,10 @@ variable "admin_security_principle_id" {
   type        = string
   default     = null
 }
+
+# Log Analytics Workspace
+
+variable "log_analytics_workspace_id" {
+  description = "Log Analytics Workspace ID used for saving key vault diagnostics"
+  type        = string
+}

--- a/modules/gateway/main.tf
+++ b/modules/gateway/main.tf
@@ -32,6 +32,11 @@ resource "azurerm_application_gateway" "graphdb-public" {
     max_capacity = var.gateway_max_capacity
   }
 
+  global {
+    request_buffering_enabled  = var.gateway_global_request_buffering_enabled
+    response_buffering_enabled = var.gateway_global_response_buffering_enabled
+  }
+
   enable_http2 = true
 
   sku {
@@ -160,6 +165,11 @@ resource "azurerm_application_gateway" "graphdb-private" {
   name                = "agw-${var.resource_name_prefix}-private"
   resource_group_name = var.resource_group_name
   location            = var.location
+
+  global {
+    request_buffering_enabled  = var.gateway_global_request_buffering_enabled
+    response_buffering_enabled = var.gateway_global_response_buffering_enabled
+  }
 
   dynamic "private_link_configuration" {
     for_each = var.gateway_enable_private_link_service ? [1] : []

--- a/modules/gateway/pip.tf
+++ b/modules/gateway/pip.tf
@@ -16,4 +16,6 @@ resource "azurerm_public_ip" "graphdb_public_ip_address" {
   allocation_method = "Static"
   zones             = var.zones
   domain_name_label = "${var.resource_name_prefix}-${random_string.ip_domain_name_suffix.result}"
+
+  idle_timeout_in_minutes = var.gateway_pip_idle_timeout
 }

--- a/modules/gateway/variables.tf
+++ b/modules/gateway/variables.tf
@@ -93,7 +93,7 @@ variable "gateway_backend_protocol" {
 }
 
 variable "gateway_backend_request_timeout" {
-  description = "Backend request timeout in minutes"
+  description = "Backend request timeout in seconds"
   type        = number
   default     = 86400 # 1 day
 }
@@ -159,4 +159,12 @@ variable "gateway_private_link_service_network_policies_enabled" {
   description = "Enable or disable private link service network policies"
   type        = string
   default     = false
+}
+
+# Public IP configurations
+
+variable "gateway_pip_idle_timeout" {
+  description = "Specifies the timeout for the TCP idle connection"
+  type        = number
+  default     = 5
 }

--- a/modules/gateway/variables.tf
+++ b/modules/gateway/variables.tf
@@ -168,3 +168,14 @@ variable "gateway_pip_idle_timeout" {
   type        = number
   default     = 5
 }
+
+# Proxy buffer configurations
+variable "gateway_global_request_buffering_enabled" {
+  description = "Whether Application Gateway's Request buffer is enabled."
+  type        = bool
+}
+
+variable "gateway_global_response_buffering_enabled" {
+  description = "Whether Application Gateway's Response buffer is enabled."
+  type        = bool
+}

--- a/modules/graphdb/nat.tf
+++ b/modules/graphdb/nat.tf
@@ -15,6 +15,8 @@ resource "azurerm_public_ip" "graphdb_nat_gateway" {
   sku               = "Standard"
   allocation_method = "Static"
   zones             = [local.nat_zone]
+
+  idle_timeout_in_minutes = var.nat_gateway_pip_idle_timeout
 }
 
 resource "azurerm_nat_gateway" "graphdb" {

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -286,3 +286,11 @@ variable "scaleset_actions_recipients_email_list" {
   description = "List of emails which will be notified for any scaling changes in the VMSS"
   type        = list(string)
 }
+
+# Public IP configurations
+
+variable "nat_gateway_pip_idle_timeout" {
+  description = "Specifies the timeout for the TCP idle connection"
+  type        = number
+  default     = 5
+}

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -40,15 +40,11 @@ resource "azurerm_role_assignment" "graphdb_key_vault_manager" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "key_vault_diagnostic_settings" {
-  name               = "Key Vault diagnostic settings"
-  target_resource_id = azurerm_key_vault.graphdb.id
-  storage_account_id = var.storage_account_id
+  name                       = "Key Vault diagnostic settings"
+  target_resource_id         = azurerm_key_vault.graphdb.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
 
   enabled_log {
     category = "AuditEvent"
-  }
-
-  metric {
-    category = "AllMetrics"
   }
 }

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -52,9 +52,9 @@ variable "admin_security_principle_id" {
   default     = null
 }
 
-# Storage account
+# Log Analytics Workspace
 
-variable "storage_account_id" {
-  description = "Storage account ID used for saving key vault diagnostics"
+variable "log_analytics_workspace_id" {
+  description = "Log Analytics Workspace ID used for saving key vault diagnostics"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,19 @@ variable "management_cidr_blocks" {
   type        = list(string)
 }
 
+# Application Gateway Global Proxy buffer configurations
+variable "gateway_global_request_buffering_enabled" {
+  description = "Whether Application Gateway's Request buffer is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "gateway_global_response_buffering_enabled" {
+  description = "Whether Application Gateway's Response buffer is enabled."
+  type        = bool
+  default     = false
+}
+
 # Inbound/Outbound network security rules
 # Note that these should be taken into considerations when gateway_enable_private_access=true
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "lock_resources" {
 
 # Networking
 
+variable "graphdb_external_address_fqdn" {
+  description = "External FQDN address for the deployment"
+  type        = string
+  default     = null
+}
+
 variable "virtual_network_address_space" {
   description = "Virtual network address space CIDRs."
   type        = list(string)
@@ -410,3 +416,4 @@ variable "notification_recipients_email_list" {
   type        = list(string)
   default     = []
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = "~>1.7.4"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
## Description

Added idle timeout variable for App GW PIP and NAT GW PIP
Fixed type-o
Added graphdb_external_address_fqdn variable to provide already available domain name
Disabled Application Gateway global proxy buffer by default.
Bumped required Terraform version to 1.7.4.
Added azurerm_monitor_diagnostic_setting to Application Config
Migrated Key Vault diagnostic settings to use Log Analytics workspace instead of the storage account as it will be deprecated.

## Related Issues

GDB-9640

## Changes

Added idle timeout variable for App GW PIP and NAT GW PIP
Fixed type-o
Added graphdb_external_address_fqdn variable to provide already available domain name

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
