### PR TITLE
GDB-9626: Purge protection and soft delete options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # GraphDB Azure Terraform Module Changelog
 
-## 0.1.0
+## 1.0.0
 
 Initial version for the GraphDB Azure module

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher onto
 | tls\_certificate\_password | TLS certificate password for password protected certificates. | `string` | `null` | no |
 | tls\_certificate\_id | Resource identifier for a TLS certificate secret from a Key Vault. Overrides tls\_certificate\_path | `string` | `null` | no |
 | tls\_certificate\_identity\_id | Identifier of a managed identity giving access to the TLS certificate specified with tls\_certificate\_id | `string` | `null` | no |
-| key\_vault\_enable\_purge\_protection | Prevents purging the key vault and its contents by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `false` | no |
-| key\_vault\_retention\_days | Retention period in days during which soft deleted secrets are kept | `number` | `30` | no |
-| app\_config\_enable\_purge\_protection | Prevents purging the App Configuration and its keys by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `false` | no |
-| app\_config\_retention\_days | Retention period in days during which soft deleted keys are kept | `number` | `7` | no |
+| key\_vault\_enable\_purge\_protection | Prevents purging the key vault and its contents by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `true` | no |
+| key\_vault\_soft\_delete\_retention\_days | Retention period in days during which soft deleted secrets are kept | `number` | `30` | no |
+| app\_config\_enable\_purge\_protection | Prevents purging the App Configuration and its keys by soft deleting it. It will be deleted once the soft delete retention has passed. | `bool` | `true` | no |
+| app\_config\_soft\_delete\_retention\_days | Retention period in days during which soft deleted keys are kept | `number` | `7` | no |
 | admin\_security\_principle\_id | UUID of a user or service principle that will become data owner or administrator for specific resources that need permissions to insert data during Terraform apply, i.e. KeyVault and AppConfig. If left unspecified, the current user will be used. | `string` | `null` | no |
-| graphdb\_version | GraphDB version from the marketplace offer | `string` | `"10.6.0"` | no |
+| graphdb\_version | GraphDB version from the marketplace offer | `string` | `"10.6.1"` | no |
 | graphdb\_sku | GraphDB SKU from the marketplace offer | `string` | `"graphdb-byol"` | no |
 | graphdb\_image\_id | GraphDB image ID to use for the scale set VM instances in place of the default marketplace offer | `string` | `null` | no |
 | graphdb\_license\_path | Local path to a file, containing a GraphDB Enterprise license. | `string` | n/a | yes |
@@ -128,7 +128,10 @@ az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher onto
 | ssh\_key | Public key for accessing the GraphDB instances | `string` | `null` | no |
 | storage\_account\_tier | Specify the performance and redundancy characteristics of the Azure Storage Account that you are creating | `string` | `"Standard"` | no |
 | storage\_account\_replication\_type | Specify the data redundancy strategy for your Azure Storage Account | `string` | `"ZRS"` | no |
+| storage\_blobs\_max\_days\_since\_creation | Specifies the retention period in days since creation before deleting storage blobs | `number` | `31` | no |
 | storage\_account\_retention\_hot\_to\_cool | Specifies the retention period in days between moving data from hot to cool tier storage | `number` | `3` | no |
+| storage\_container\_soft\_delete\_retention\_policy | Number of days for retaining the storage container from actual deletion | `number` | `31` | no |
+| storage\_blob\_soft\_delete\_retention\_policy | Number of days for retaining storage blobs from actual deletion | `number` | `31` | no |
 | backup\_schedule | Cron expression for the backup job. | `string` | `"0 0 * * *"` | no |
 | deploy\_bastion | Deploy bastion module | `bool` | `false` | no |
 | bastion\_subnet\_address\_prefixes | Bastion subnet address prefixes | `list(string)` | ```[ "10.0.3.0/26" ]``` | no |

--- a/README.md
+++ b/README.md
@@ -242,6 +242,26 @@ There are two options for setting up the Application Gateway with a TLS certific
     tls_certificate_identity_id = "managed-identity-id"
     ```
 
+**Purge Protection**
+
+Resources that support purge protection and soft delete have them enabled by default. 
+You can override the default configurations with the following variables:
+
+```hcl
+# Make sure the resource group delete lock is enabled for production
+lock_resources = true
+
+# Configure Key Vault purge protection in case of local TLS certificate usage
+key_vault_enable_purge_protection    = true
+key_vault_soft_delete_retention_days = 7 # From 7 to 90 days
+
+app_config_enable_purge_protection    = true
+app_config_soft_delete_retention_days = 7 # From 1 to 7 days
+
+storage_container_soft_delete_retention_policy = 7 # From 1 to 365 days
+storage_blob_soft_delete_retention_policy      = 7 # From 1 to 365 days
+```
+
 <!---
 TODO Add more examples
 -->

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_management_lock" "graphdb_rg_lock" {
   name       = "${var.resource_name_prefix}-rg"
   scope      = azurerm_resource_group.graphdb.id
   lock_level = "CanNotDelete"
-  notes      = "Prevents deleting the resource group"
+  notes      = "Prevents from deleting the resource group"
 }
 
 resource "azurerm_virtual_network" "graphdb" {
@@ -72,8 +72,8 @@ module "vault" {
   nacl_subnet_ids = [azurerm_subnet.graphdb_gateway.id]
   nacl_ip_rules   = var.management_cidr_blocks
 
-  key_vault_enable_purge_protection = var.key_vault_enable_purge_protection
-  key_vault_retention_days          = var.key_vault_retention_days
+  key_vault_enable_purge_protection    = var.key_vault_enable_purge_protection
+  key_vault_soft_delete_retention_days = var.key_vault_soft_delete_retention_days
 
   admin_security_principle_id = local.admin_security_principle_id
   log_analytics_workspace_id  = module.monitoring[0].la_workspace_id
@@ -92,7 +92,11 @@ module "backup" {
 
   storage_account_tier                  = var.storage_account_tier
   storage_account_replication_type      = var.storage_account_replication_type
+  storage_blobs_max_days_since_creation = var.storage_blobs_max_days_since_creation
   storage_account_retention_hot_to_cool = var.storage_account_retention_hot_to_cool
+
+  storage_container_soft_delete_retention_policy = var.storage_container_soft_delete_retention_policy
+  storage_blob_soft_delete_retention_policy      = var.storage_blob_soft_delete_retention_policy
 }
 
 # Creates an App Configuration store for managing GraphDB specific configurations
@@ -103,8 +107,8 @@ module "appconfig" {
   location             = var.location
   resource_group_name  = azurerm_resource_group.graphdb.name
 
-  app_config_enable_purge_protection = var.app_config_enable_purge_protection
-  app_config_retention_days          = var.app_config_retention_days
+  app_config_enable_purge_protection    = var.app_config_enable_purge_protection
+  app_config_soft_delete_retention_days = var.app_config_soft_delete_retention_days
 
   admin_security_principle_id = local.admin_security_principle_id
 

--- a/modules/appconfig/main.tf
+++ b/modules/appconfig/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_app_configuration" "graphdb" {
   public_network_access      = "Enabled"
   local_auth_enabled         = false
   purge_protection_enabled   = var.app_config_enable_purge_protection
-  soft_delete_retention_days = var.app_config_retention_days
+  soft_delete_retention_days = var.app_config_soft_delete_retention_days
 }
 
 resource "azurerm_monitor_diagnostic_setting" "application_config_diagnostic_settings" {

--- a/modules/appconfig/variables.tf
+++ b/modules/appconfig/variables.tf
@@ -17,14 +17,12 @@ variable "resource_group_name" {
 
 # App Configuration
 
-# Enable only for production
 variable "app_config_enable_purge_protection" {
   description = "Prevents purging the App Configuration and its keys by soft deleting it. It will be deleted once the soft delete retention has passed."
   type        = bool
-  default     = false
 }
 
-variable "app_config_retention_days" {
+variable "app_config_soft_delete_retention_days" {
   description = "Retention period in days during which soft deleted keys are kept"
   type        = number
   default     = 7
@@ -35,7 +33,6 @@ variable "app_config_retention_days" {
 variable "admin_security_principle_id" {
   description = "UUID of a user or service principle that will become App Configuration data owner"
   type        = string
-  default     = null
 }
 
 # Log Analytics Workspace

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -33,6 +33,19 @@ resource "azurerm_storage_account" "graphdb_backup" {
   shared_access_key_enabled         = false
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
+  allowed_copy_scope                = var.storage_account_allowed_copy_scope
+
+  blob_properties {
+    container_delete_retention_policy {
+      days = var.storage_container_soft_delete_retention_policy
+    }
+    delete_retention_policy {
+      days = var.storage_blob_soft_delete_retention_policy
+    }
+    last_access_time_enabled      = true
+    change_feed_enabled           = true
+    change_feed_retention_in_days = var.storage_blobs_max_days_since_creation
+  }
 
   network_rules {
     bypass                     = ["AzureServices"]
@@ -60,13 +73,13 @@ resource "azurerm_storage_management_policy" "graphdb_backup_retention" {
     }
     actions {
       base_blob {
-        delete_after_days_since_modification_greater_than = 31
+        delete_after_days_since_creation_greater_than = var.storage_blobs_max_days_since_creation
       }
       snapshot {
-        delete_after_days_since_creation_greater_than = 31
+        delete_after_days_since_creation_greater_than = var.storage_blobs_max_days_since_creation
       }
       version {
-        delete_after_days_since_creation = 31
+        delete_after_days_since_creation = var.storage_blobs_max_days_since_creation
       }
     }
   }

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -49,8 +49,34 @@ variable "storage_account_replication_type" {
   default     = "ZRS"
 }
 
+variable "storage_account_allowed_copy_scope" {
+  description = "Restricts copy operations to and from Storage Accounts"
+  type        = string
+  default     = "AAD"
+}
+
+# Lifecycle
+
+variable "storage_blobs_max_days_since_creation" {
+  description = "Specifies the retention period in days since creation before deleting storage blobs"
+  type        = number
+}
+
 variable "storage_account_retention_hot_to_cool" {
   description = "Specifies the retention period in days between moving data from hot to cool tier storage"
   type        = number
-  default     = 3
+}
+
+# Data protection
+
+variable "storage_container_soft_delete_retention_policy" {
+  description = "Number of days for retaining the storage container from actual deletion"
+  type        = number
+  default     = 7
+}
+
+variable "storage_blob_soft_delete_retention_policy" {
+  description = "Number of days for retaining storage blobs from actual deletion"
+  type        = number
+  default     = 7
 }

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_key_vault" "graphdb" {
   sku_name                   = "standard"
   enable_rbac_authorization  = true
   purge_protection_enabled   = var.key_vault_enable_purge_protection
-  soft_delete_retention_days = var.key_vault_retention_days
+  soft_delete_retention_days = var.key_vault_soft_delete_retention_days
 
   network_acls {
     bypass                     = "AzureServices"

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -31,14 +31,12 @@ variable "nacl_ip_rules" {
 
 # Key Vault
 
-# Enable only for production
 variable "key_vault_enable_purge_protection" {
   description = "Prevents purging the key vault and its contents by soft deleting it. It will be deleted once the soft delete retention has passed."
   type        = bool
-  default     = false
 }
 
-variable "key_vault_retention_days" {
+variable "key_vault_soft_delete_retention_days" {
   description = "Retention period in days during which soft deleted secrets are kept"
   type        = number
   default     = 7
@@ -49,7 +47,6 @@ variable "key_vault_retention_days" {
 variable "admin_security_principle_id" {
   description = "UUID of a user or service principle that will become Key Vault administrator"
   type        = string
-  default     = null
 }
 
 # Log Analytics Workspace

--- a/provider.tf
+++ b/provider.tf
@@ -9,6 +9,9 @@ provider "azurerm" {
     key_vault {
       purge_soft_delete_on_destroy = true
     }
+    app_configuration {
+      purge_soft_delete_on_destroy = true
+    }
   }
   # Required when shared_access_key_enabled is false
   storage_use_azuread = true

--- a/variables.tf
+++ b/variables.tf
@@ -157,38 +157,36 @@ variable "tls_certificate_identity_id" {
 
 # Key Vault
 
-# Enable only for production
 variable "key_vault_enable_purge_protection" {
   description = "Prevents purging the key vault and its contents by soft deleting it. It will be deleted once the soft delete retention has passed."
   type        = bool
-  default     = false
+  default     = true
 }
 
-variable "key_vault_retention_days" {
+variable "key_vault_soft_delete_retention_days" {
   description = "Retention period in days during which soft deleted secrets are kept"
   type        = number
   default     = 30
   validation {
-    condition     = var.key_vault_retention_days >= 7 && var.key_vault_retention_days <= 90
+    condition     = var.key_vault_soft_delete_retention_days >= 7 && var.key_vault_soft_delete_retention_days <= 90
     error_message = "Key Vault soft delete retention days must be between 7 and 90 (inclusive)"
   }
 }
 
 # App Configuration
 
-# Enable only for production
 variable "app_config_enable_purge_protection" {
   description = "Prevents purging the App Configuration and its keys by soft deleting it. It will be deleted once the soft delete retention has passed."
   type        = bool
-  default     = false
+  default     = true
 }
 
-variable "app_config_retention_days" {
+variable "app_config_soft_delete_retention_days" {
   description = "Retention period in days during which soft deleted keys are kept"
   type        = number
   default     = 7
   validation {
-    condition     = var.app_config_retention_days >= 1 && var.app_config_retention_days <= 7
+    condition     = var.app_config_soft_delete_retention_days >= 1 && var.app_config_soft_delete_retention_days <= 7
     error_message = "App Configuration soft delete retention days must be between 1 and 7 (inclusive)"
   }
 }
@@ -206,7 +204,7 @@ variable "admin_security_principle_id" {
 variable "graphdb_version" {
   description = "GraphDB version from the marketplace offer"
   type        = string
-  default     = "10.6.0"
+  default     = "10.6.1"
 }
 
 variable "graphdb_sku" {
@@ -273,7 +271,7 @@ variable "ssh_key" {
   default     = null
 }
 
-# Storage account
+# Storage account, primarily used for GraphDB backups
 
 variable "storage_account_tier" {
   description = "Specify the performance and redundancy characteristics of the Azure Storage Account that you are creating"
@@ -287,10 +285,36 @@ variable "storage_account_replication_type" {
   default     = "ZRS"
 }
 
+variable "storage_blobs_max_days_since_creation" {
+  description = "Specifies the retention period in days since creation before deleting storage blobs"
+  type        = number
+  default     = 31
+}
+
 variable "storage_account_retention_hot_to_cool" {
   description = "Specifies the retention period in days between moving data from hot to cool tier storage"
   type        = number
   default     = 3
+}
+
+variable "storage_container_soft_delete_retention_policy" {
+  description = "Number of days for retaining the storage container from actual deletion"
+  type        = number
+  default     = 31
+  validation {
+    condition     = var.storage_container_soft_delete_retention_policy >= 1 && var.storage_container_soft_delete_retention_policy <= 365
+    error_message = "Storage container soft delete retention days must be between 1 and 365 (inclusive)"
+  }
+}
+
+variable "storage_blob_soft_delete_retention_policy" {
+  description = "Number of days for retaining storage blobs from actual deletion"
+  type        = number
+  default     = 31
+  validation {
+    condition     = var.storage_blob_soft_delete_retention_policy >= 1 && var.storage_blob_soft_delete_retention_policy <= 365
+    error_message = "Storage blobs soft delete retention days must be between 1 and 365 (inclusive)"
+  }
 }
 
 # Backup configurations
@@ -324,7 +348,6 @@ variable "deploy_monitoring" {
 }
 
 # Managed disks
-
 
 variable "disk_size_gb" {
   description = "Size of the managed data disk which will be created"


### PR DESCRIPTION
## Changes

- Added soft delete configurations for the storage account
- Added example in the readme for configuring purge protection and soft delete policies
- Bumped GraphDB to version 10.6.1
- Renamed some variables to follow a better naming convention
- Added configuration for the storage account's copy rule
- Added configuration for the storage account's max days lifecycle

## Related Issues

https://ontotext.atlassian.net/browse/GDB-9626
