### PR TITLE
GDB-9698: Wait for resources in the user data script

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.91.0"
   constraints = "~> 3.91.0"
   hashes = [
+    "h1:LagYfbO2xfkGMMisggbfFMbVZd00ZPYnOVGig+935e0=",
     "h1:t0I5G4canK6UdlgHGfMV4rUNBPGdrMiIB01VGizlXB8=",
     "zh:13928b71b1235783f3f877a799e28fb91e50512b051eb8ccb370500fc140cf3f",
     "zh:3264341657e9ff3963d69b0fa088f64665349e2a29b2f3aeb4deee6d9d7584b7",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.3"
   constraints = "~> 2.3.3"
   hashes = [
+    "h1:TNvKS2y0rYHkZgb0wabYGLKAFOnDiFbvHwoXnuOF4o8=",
     "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
     "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
     "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.6.0"
   hashes = [
     "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
+    "h1:S8bSIs06Vd8C/tmrTJdRyGHH1wHz+2fTfF4+jwlylrM=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
@@ -66,6 +69,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.10.0"
   hashes = [
     "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
+    "h1:XiRMsGFEe6VTWGL0O32l8viW2fI8wXyJFRJYfdQR8os=",
     "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
     "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",
     "zh:3bbb3e9da728b82428c6f18533b5b7c014e8ff1b8d9b2587107c966b985e5bcc",

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,8 +5,6 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.91.0"
   constraints = "~> 3.91.0"
   hashes = [
-    "h1:FEDNnFv/uKI2+FQ+nDoyswEI3trJ3d7Fx2Cy7Ff4Rq8=",
-    "h1:LagYfbO2xfkGMMisggbfFMbVZd00ZPYnOVGig+935e0=",
     "h1:t0I5G4canK6UdlgHGfMV4rUNBPGdrMiIB01VGizlXB8=",
     "zh:13928b71b1235783f3f877a799e28fb91e50512b051eb8ccb370500fc140cf3f",
     "zh:3264341657e9ff3963d69b0fa088f64665349e2a29b2f3aeb4deee6d9d7584b7",
@@ -27,8 +25,6 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.3"
   constraints = "~> 2.3.3"
   hashes = [
-    "h1:TCZQjXesJ9qbOZaHjJse/WyOxYQwp7wUX3VNxL/qo1c=",
-    "h1:TNvKS2y0rYHkZgb0wabYGLKAFOnDiFbvHwoXnuOF4o8=",
     "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
     "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
     "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
@@ -50,8 +46,6 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.6.0"
   hashes = [
     "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
-    "h1:S8bSIs06Vd8C/tmrTJdRyGHH1wHz+2fTfF4+jwlylrM=",
-    "h1:t0mRdJzegohRKhfdoQEJnv3JRISSezJRblN0HIe67vo=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
@@ -72,8 +66,6 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.10.0"
   hashes = [
     "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
-    "h1:XiRMsGFEe6VTWGL0O32l8viW2fI8wXyJFRJYfdQR8os=",
-    "h1:rPbqd7mEyBetQPjyBDBAdwiARulKbh2LwzQp2GSl/AI=",
     "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
     "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",
     "zh:3bbb3e9da728b82428c6f18533b5b7c014e8ff1b8d9b2587107c966b985e5bcc",

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher onto
 | appi\_web\_test\_availability\_enabled | Should the availability web test be enabled | `bool` | `true` | no |
 | web\_test\_ssl\_check\_enabled | Should the SSL check be enabled? | `bool` | `false` | no |
 | web\_test\_geo\_locations | A list of geo locations the test will be executed from | `list(string)` | ```[ "us-va-ash-azr", "us-il-ch1-azr", "emea-gb-db3-azr", "emea-nl-ams-azr", "apac-hk-hkn-azr" ]``` | no |
-| monitor\_reader\_principal\_id | Principal(Object) ID of a user/group which would receive notifications from alerts. | `string` | n/a | yes |
+| monitor\_reader\_principal\_id | Principal(Object) ID of a user/group which would receive notifications from alerts. | `string` | `null` | no |
 | notification\_recipients\_email\_list | List of emails which will be notified via e-mail and/or push notifications | `list(string)` | `[]` | no |
 <!-- END_TF_DOCS -->
 

--- a/main.tf
+++ b/main.tf
@@ -76,8 +76,6 @@ module "vault" {
   key_vault_soft_delete_retention_days = var.key_vault_soft_delete_retention_days
 
   admin_security_principle_id = local.admin_security_principle_id
-
-  log_analytics_workspace_id = var.deploy_monitoring ? module.monitoring[0].la_workspace_id : null
 }
 
 # Creates a Storage Account for storing GraphDB backups
@@ -112,8 +110,6 @@ module "appconfig" {
   app_config_soft_delete_retention_days = var.app_config_soft_delete_retention_days
 
   admin_security_principle_id = local.admin_security_principle_id
-
-  log_analytics_workspace_id = var.deploy_monitoring ? module.monitoring[0].la_workspace_id : null
 }
 
 # Creates a TLS certificate secret in the Key Vault and related identity (if file is provided)
@@ -210,6 +206,10 @@ module "monitoring" {
   la_workspace_retention_in_days = var.la_workspace_retention_in_days
 
   ag_notifications_email_list = var.notification_recipients_email_list
+
+  # Diagnostic settings
+  app_configuration_id = module.appconfig.app_configuration_id
+  kv_id                = module.vault[0].key_vault_id
 }
 
 # Creates a VM scale set for GraphDB and GraphDB cluster proxies

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,8 @@ module "vault" {
   key_vault_soft_delete_retention_days = var.key_vault_soft_delete_retention_days
 
   admin_security_principle_id = local.admin_security_principle_id
-  log_analytics_workspace_id  = module.monitoring[0].la_workspace_id
+
+  log_analytics_workspace_id = var.deploy_monitoring ? module.monitoring[0].la_workspace_id : null
 }
 
 # Creates a Storage Account for storing GraphDB backups
@@ -112,7 +113,7 @@ module "appconfig" {
 
   admin_security_principle_id = local.admin_security_principle_id
 
-  log_analytics_workspace_id = module.monitoring[0].la_workspace_id
+  log_analytics_workspace_id = var.deploy_monitoring ? module.monitoring[0].la_workspace_id : null
 }
 
 # Creates a TLS certificate secret in the Key Vault and related identity (if file is provided)

--- a/modules/appconfig/main.tf
+++ b/modules/appconfig/main.tf
@@ -25,18 +25,6 @@ resource "azurerm_app_configuration" "graphdb" {
   soft_delete_retention_days = var.app_config_soft_delete_retention_days
 }
 
-resource "azurerm_monitor_diagnostic_setting" "application_config_diagnostic_settings" {
-  count = var.log_analytics_workspace_id != null ? 1 : 0
-
-  name                       = "Application Config diagnostic settings"
-  target_resource_id         = azurerm_app_configuration.graphdb.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
-
-  enabled_log {
-    category = "Audit"
-  }
-}
-
 resource "azurerm_role_assignment" "app_config_data_owner" {
   principal_id         = var.admin_security_principle_id
   scope                = azurerm_app_configuration.graphdb.id

--- a/modules/appconfig/main.tf
+++ b/modules/appconfig/main.tf
@@ -26,6 +26,8 @@ resource "azurerm_app_configuration" "graphdb" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "application_config_diagnostic_settings" {
+  count = var.log_analytics_workspace_id != null ? 1 : 0
+
   name                       = "Application Config diagnostic settings"
   target_resource_id         = azurerm_app_configuration.graphdb.id
   log_analytics_workspace_id = var.log_analytics_workspace_id

--- a/modules/appconfig/variables.tf
+++ b/modules/appconfig/variables.tf
@@ -34,11 +34,3 @@ variable "admin_security_principle_id" {
   description = "UUID of a user or service principle that will become App Configuration data owner"
   type        = string
 }
-
-# Log Analytics Workspace
-
-variable "log_analytics_workspace_id" {
-  description = "Log Analytics Workspace ID used for saving key vault diagnostics"
-  type        = string
-  default     = null
-}

--- a/modules/appconfig/variables.tf
+++ b/modules/appconfig/variables.tf
@@ -40,4 +40,5 @@ variable "admin_security_principle_id" {
 variable "log_analytics_workspace_id" {
   description = "Log Analytics Workspace ID used for saving key vault diagnostics"
   type        = string
+  default     = null
 }

--- a/modules/graphdb/identity.tf
+++ b/modules/graphdb/identity.tf
@@ -8,9 +8,10 @@ resource "azurerm_user_assigned_identity" "graphdb_vmss" {
   location            = var.location
 }
 
-resource "azurerm_role_assignment" "graphdb_vmss_app_config_reader" {
+# Required by the 00_wait_resources.sh.tpl template
+resource "azurerm_role_assignment" "graphdb_rg_reader" {
   principal_id         = azurerm_user_assigned_identity.graphdb_vmss.principal_id
-  scope                = var.app_configuration_id
+  scope                = var.resource_group_id
   role_definition_name = "Reader"
 }
 

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -102,27 +102,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "graphdb" {
     username   = "graphdb"
   }
 
-  # Wait for dependent resources (until we add retry mechanism in the user data script)
   depends_on = [
-    # DNS
-    azurerm_private_dns_zone.graphdb,
-    azurerm_private_dns_zone_virtual_network_link.graphdb,
-    # NAT
-    azurerm_nat_gateway.graphdb,
-    azurerm_nat_gateway_public_ip_association.graphdb_nat_gateway,
-    azurerm_subnet_nat_gateway_association.graphdb_nat_gateway,
-    # Disks
-    azurerm_managed_disk.managed_disks,
-    # NSG
-    azurerm_network_security_group.graphdb_vmss,
-    azurerm_subnet_network_security_group_association.graphdb_vmss,
-    # TODO: wait for internal and outbound rules?
-    # Configurations
-    azurerm_app_configuration_key.graphdb_cluster_token,
-    azurerm_app_configuration_key.graphdb_java_options,
-    azurerm_app_configuration_key.graphdb_license,
-    azurerm_app_configuration_key.graphdb_password,
-    azurerm_app_configuration_key.graphdb_properties
+    azurerm_managed_disk.managed_disks
   ]
 }
 

--- a/modules/graphdb/templates/00_wait_resources.sh.tpl
+++ b/modules/graphdb/templates/00_wait_resources.sh.tpl
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This scripts wait for resources on which the VM relies to exists and with access to
+# Because Terraform creates resources in parallel, the VM could try to access a resources that is still being created in Azure in the background
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RESOURCE_GROUP=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2021-01-01&format=text")
+
+POLL_INTERVAL=5
+MAX_TIMEOUT=600
+
+# Provided by Terraform
+PRIVATE_DNS_ZONE_NAME="${private_dns_zone_name}"
+PRIVATE_DNS_ZONE_ID="${private_dns_zone_id}"
+PRIVATE_DNS_ZONE_LINK_NAME="${private_dns_zone_link_name}"
+PRIVATE_DNS_ZONE_LINK_ID="${private_dns_zone_link_id}"
+APP_CONFIGURATION_NAME="${app_configuration_name}"
+APP_CONFIGURATION_ID="${app_configuration_id}"
+STORAGE_ACCOUNT_NAME=${storage_account_name}
+
+echo "Waiting for Private DNS zone: $PRIVATE_DNS_ZONE_NAME"
+time az resource wait \
+   --resource-group "$RESOURCE_GROUP" \
+   --ids "$PRIVATE_DNS_ZONE_ID" \
+   --namespace "Microsoft.Network" \
+   --resource-type "privateDnsZones" \
+   --created \
+   --interval $POLL_INTERVAL \
+   --timeout $MAX_TIMEOUT
+
+echo "Waiting for Private DNS zone link: $PRIVATE_DNS_ZONE_LINK_NAME"
+time az resource wait \
+   --resource-group "$RESOURCE_GROUP" \
+   --ids "$PRIVATE_DNS_ZONE_LINK_ID" \
+   --namespace "Microsoft.Network" \
+   --resource-type "privateDnsZones/virtualNetworkLinks" \
+   --created \
+   --interval $POLL_INTERVAL \
+   --timeout $MAX_TIMEOUT
+
+echo "Waiting for App Configuration: $APP_CONFIGURATION_NAME"
+time az resource wait \
+   --resource-group "$RESOURCE_GROUP" \
+   --ids "$APP_CONFIGURATION_ID" \
+   --namespace "Microsoft.AppConfiguration" \
+   --resource-type "configurationStores" \
+   --created \
+   --interval $POLL_INTERVAL \
+   --timeout $MAX_TIMEOUT
+
+echo "Waiting for Storage Account: $STORAGE_ACCOUNT_NAME"
+time az resource wait \
+   --resource-group "$RESOURCE_GROUP" \
+   --name "$STORAGE_ACCOUNT_NAME" \
+   --namespace "Microsoft.Storage" \
+   --resource-type "storageAccounts" \
+   --created \
+   --interval $POLL_INTERVAL \
+   --timeout $MAX_TIMEOUT
+
+echo "#########################################################"
+echo "# Finished waiting for dependent resources and services #"
+echo "#########################################################"

--- a/modules/graphdb/templates/02_dns_provisioning.sh.tpl
+++ b/modules/graphdb/templates/02_dns_provisioning.sh.tpl
@@ -23,17 +23,7 @@ RESOURCE_GROUP=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/insta
 IP_ADDRESS=$(hostname -I | awk '{print $1}')
 VMSS_NAME=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/vmScaleSetName?api-version=2021-01-01&format=text")
 INSTANCE_ID=$(basename $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/resourceId?api-version=2021-01-01&format=text"))
-
-for i in $(seq 1 6); do
-  # Waits for DNS zone to be created and role assigned
-  DNS_ZONE_NAME=$(az network private-dns zone list --query "[].name" --output tsv)
-  if [ -z "$${DNS_ZONE_NAME:-}" ]; then
-    echo 'Zone not available yet'
-    sleep 10
-  else
-    break
-  fi
-done
+DNS_ZONE_NAME=${private_dns_zone_name}
 
 # Get all FQDN records from the private DNS zone containing "node"
 readarray -t ALL_FQDN_RECORDS <<< "$(az network private-dns record-set list -z $DNS_ZONE_NAME --resource-group $RESOURCE_GROUP --query "[?contains(name, 'node')].fqdn" --output tsv)"
@@ -99,4 +89,3 @@ for i in "$${!SORTED_INSTANCE_IDS[@]}"; do
 
   break
 done
-

--- a/modules/graphdb/templates/07_cluster_setup.sh.tpl
+++ b/modules/graphdb/templates/07_cluster_setup.sh.tpl
@@ -19,7 +19,7 @@ echo "###########################"
 
 INSTANCE_ID=$(basename $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/resourceId?api-version=2021-01-01&format=text"))
 RESOURCE_GROUP=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2021-01-01&format=text")
-DNS_ZONE_NAME=$(az network private-dns zone list --query "[].name" --output tsv)
+DNS_ZONE_NAME=${private_dns_zone_name}
 GRAPHDB_ADMIN_PASSWORD="$(az appconfig kv show --name ${app_config_name} --auth-mode login --key graphdb-password | jq -r .value | base64 -d)"
 GRAPHDB_PASSWORD_CREATION_TIME="$(az appconfig kv show --name ${app_config_name} --auth-mode login --key graphdb-password | jq -r .lastModified)"
 LOWEST_INSTANCE_ID=$(cat /tmp/lowest_id)

--- a/modules/monitoring/diagnostic_settings.tf
+++ b/modules/monitoring/diagnostic_settings.tf
@@ -1,0 +1,24 @@
+# Application config Audit log monitoring
+
+resource "azurerm_monitor_diagnostic_setting" "application_config_diagnostic_settings" {
+  name                       = "Application Config diagnostic settings"
+  target_resource_id         = var.app_configuration_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
+
+  enabled_log {
+    category = "Audit"
+  }
+}
+
+# Key Vault Audit log monitoring
+
+resource "azurerm_monitor_diagnostic_setting" "key_vault_diagnostic_settings" {
+
+  name                       = "Key Vault diagnostic settings"
+  target_resource_id         = var.kv_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
+
+  enabled_log {
+    category = "AuditEvent"
+  }
+}

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -120,12 +120,6 @@ variable "ag_notifications_email_list" {
   type        = list(string)
 }
 
-variable "ag_arm_role_receiver_role_id" {
-  description = "Principal(Object) ID of the role which will receive e-mails. Defaults to the owner built-in role"
-  type        = string
-  default     = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
-}
-
 variable "enable_alerts" {
   description = "Should the alerts be enabled"
   type        = bool

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -137,3 +137,14 @@ variable "al_low_memory_warning_threshold" {
   type        = number
   default     = 90
 }
+
+variable "app_configuration_id" {
+  description = "ID of the Application Config resource, required for diagnostic settings"
+  type        = string
+}
+
+variable "kv_id" {
+  description = "ID of the Key Vault resource, required for diagnostic settings"
+  type        = string
+}
+

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -39,14 +39,3 @@ resource "azurerm_role_assignment" "graphdb_key_vault_manager" {
   role_definition_name = "Key Vault Administrator"
 }
 
-resource "azurerm_monitor_diagnostic_setting" "key_vault_diagnostic_settings" {
-  count = var.log_analytics_workspace_id != null ? 1 : 0
-
-  name                       = "Key Vault diagnostic settings"
-  target_resource_id         = azurerm_key_vault.graphdb.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
-
-  enabled_log {
-    category = "AuditEvent"
-  }
-}

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -40,6 +40,8 @@ resource "azurerm_role_assignment" "graphdb_key_vault_manager" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "key_vault_diagnostic_settings" {
+  count = var.log_analytics_workspace_id != null ? 1 : 0
+
   name                       = "Key Vault diagnostic settings"
   target_resource_id         = azurerm_key_vault.graphdb.id
   log_analytics_workspace_id = var.log_analytics_workspace_id

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -54,4 +54,5 @@ variable "admin_security_principle_id" {
 variable "log_analytics_workspace_id" {
   description = "Log Analytics Workspace ID used for saving key vault diagnostics"
   type        = string
+  default     = null
 }

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -48,11 +48,3 @@ variable "admin_security_principle_id" {
   description = "UUID of a user or service principle that will become Key Vault administrator"
   type        = string
 }
-
-# Log Analytics Workspace
-
-variable "log_analytics_workspace_id" {
-  description = "Log Analytics Workspace ID used for saving key vault diagnostics"
-  type        = string
-  default     = null
-}

--- a/provider.tf
+++ b/provider.tf
@@ -4,13 +4,13 @@ provider "azurerm" {
       expand_without_downtime = true
     }
     resource_group {
-      prevent_deletion_if_contains_resources = true
+      prevent_deletion_if_contains_resources = false
     }
     key_vault {
-      purge_soft_delete_on_destroy = true
+      purge_soft_delete_on_destroy = false
     }
     app_configuration {
-      purge_soft_delete_on_destroy = true
+      purge_soft_delete_on_destroy = false
     }
   }
   # Required when shared_access_key_enabled is false

--- a/variables.tf
+++ b/variables.tf
@@ -445,6 +445,7 @@ variable "web_test_geo_locations" {
 variable "monitor_reader_principal_id" {
   description = "Principal(Object) ID of a user/group which would receive notifications from alerts."
   type        = string
+  default     = null
 }
 
 variable "notification_recipients_email_list" {


### PR DESCRIPTION
## Changes

- Added a new user data script that will wait for services and resources on which the GraphDB deployment depends
- Updated the existing user data scripts to accept the concrete resource names instead of querying them from az CLI
- Removed unused variable i nthe monitoring sub module
- Added handling when the monitoring is disabled

## Related Issues

https://ontotext.atlassian.net/browse/GDB-9698