### PR TITLE
Changed key_vault_diagnostic_settings to be deployed only if vault module is deployed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -209,7 +209,7 @@ module "monitoring" {
 
   # Diagnostic settings
   app_configuration_id = module.appconfig.app_configuration_id
-  kv_id                = module.vault[0].key_vault_id
+  key_vault_id         = var.tls_certificate_id != null ? null : module.vault[0].key_vault_id
 }
 
 # Creates a VM scale set for GraphDB and GraphDB cluster proxies

--- a/modules/monitoring/diagnostic_settings.tf
+++ b/modules/monitoring/diagnostic_settings.tf
@@ -13,9 +13,10 @@ resource "azurerm_monitor_diagnostic_setting" "application_config_diagnostic_set
 # Key Vault Audit log monitoring
 
 resource "azurerm_monitor_diagnostic_setting" "key_vault_diagnostic_settings" {
+  count = var.key_vault_id != null ? 1 : 0
 
   name                       = "Key Vault diagnostic settings"
-  target_resource_id         = var.kv_id
+  target_resource_id         = var.key_vault_id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
 
   enabled_log {

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -143,7 +143,7 @@ variable "app_configuration_id" {
   type        = string
 }
 
-variable "kv_id" {
+variable "key_vault_id" {
   description = "ID of the Key Vault resource, required for diagnostic settings"
   type        = string
 }


### PR DESCRIPTION
## Description

Changed key_vault_diagnostic_settings to be deployed only if vault module is deployed

## Related Issues

GDB-9903

## Changes

Changed key_vault_diagnostic_settings to be deployed only if vault module is deployed

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
