### PR TITLE
Fixed and issue with detecting cd/dvd device as gdb disk device

### DIFF
--- a/modules/graphdb/templates/01_disk_management.sh.tpl
+++ b/modules/graphdb/templates/01_disk_management.sh.tpl
@@ -135,7 +135,7 @@ disk_attach_create() {
   fi
 
   # Gets device name based on LUN 2
-  graphdb_device=$(lsscsi --scsi --size | awk '/\[1:.*:0:2\]/ {print $7}')
+  graphdb_device=$(lsscsi --scsi --size | grep -v 'cd/dvd' | awk '/\[*:.*:0:2\]/ {print $7}')
 }
 
 disk_attach_create 0


### PR DESCRIPTION
## Description

Some VMs come with an sr0 device mounted at LUN2 which makes the userdata script break because it's not the mounted disk we expect. Fixed this by adding filtering for cd/dvd devices. 

## Related Issues

<!-- Links to related issues, fixed issues or partially addressed by this PR. -->

## Changes

Added filtering for cd/dvd devices

## Screenshots (if applicable)

<!-- Add any relevant screenshots or GIFs to showcase the changes visually -->

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
