### PR TITLE
GDB-10042 Ensure the VMSS will always be able to resolve addresses in the Private DNS Zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Updated the shell options to be more descriptive.
 * Fixed the deployment of `azurerm_monitor_diagnostic_setting` for the key vault when monitoring is enabled
 * Introduced a mechanism to provide additional user data scripts via the `user_supplied_scripts` variable.
+* Added `dns_servers = ["168.63.129.16"]` to the VMSS. This allows the Private DNS zone records to be resolved
+even if a custom DNS server is set for the Virtual Network.
 
 
 ## 1.0.1

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ az vm image accept-terms --offer graphdb-ee --plan graphdb-byol --publisher onto
 | zones | Availability zones to use for resource deployment and HA | `list(number)` | ```[ 1, 2, 3 ]``` | no |
 | tags | Common resource tags. | `map(string)` | `{}` | no |
 | lock\_resources | Enables a delete lock on the resource group to prevent accidental deletions. | `bool` | `true` | no |
+| vmss\_dns\_servers | List of DNS servers for the VMSS | `list(string)` | `[]` | no |
 | graphdb\_external\_address\_fqdn | External FQDN address for the deployment | `string` | `null` | no |
 | virtual\_network\_address\_space | Virtual network address space CIDRs. | `list(string)` | ```[ "10.0.0.0/16" ]``` | no |
 | gateway\_subnet\_address\_prefixes | Subnet address prefixes CIDRs where the application gateway will reside. | `list(string)` | ```[ "10.0.1.0/24" ]``` | no |

--- a/main.tf
+++ b/main.tf
@@ -287,6 +287,7 @@ module "graphdb" {
   node_count            = var.node_count
   ssh_key               = var.ssh_key
   user_supplied_scripts = var.user_supplied_scripts
+  vmss_dns_servers      = var.vmss_dns_servers
 
   # Managed Disks
   disk_iops_read_write       = var.disk_iops_read_write

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -2,6 +2,12 @@
 # Linux VMs scale set for GraphDB
 #
 
+# Ensures the VMSS will always resolve addresses in the Private DNS Zone.
+# https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+locals {
+  dns_servers = setunion(var.vmss_dns_servers, ["168.63.129.16"])
+}
+
 resource "azurerm_linux_virtual_machine_scale_set" "graphdb" {
   name                = "vmss-${var.resource_name_prefix}"
   resource_group_name = var.resource_group_name
@@ -80,8 +86,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "graphdb" {
   }
 
   network_interface {
-    name    = "nic-${var.resource_name_prefix}-vmss"
-    primary = true
+    name        = "nic-${var.resource_name_prefix}-vmss"
+    primary     = true
+    dns_servers = local.dns_servers
 
     ip_configuration {
       name                                         = "${var.resource_name_prefix}-ip-config"

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -28,6 +28,11 @@ variable "resource_group_name" {
 
 # Networking
 
+variable "vmss_dns_servers" {
+  description = "List of DNS servers for the VMSS"
+  type        = list(string)
+}
+
 variable "virtual_network_id" {
   description = "Virtual network the DNS will be linked to"
   type        = string
@@ -300,3 +305,4 @@ variable "user_supplied_scripts" {
   description = "Array of additional shell scripts to execute sequentially after the templated user data shell scripts."
   type        = list(string)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "lock_resources" {
 
 # Networking
 
+variable "vmss_dns_servers" {
+  description = "List of DNS servers for the VMSS"
+  type        = list(string)
+  default     = []
+}
+
 variable "graphdb_external_address_fqdn" {
   description = "External FQDN address for the deployment"
   type        = string


### PR DESCRIPTION
## Description

Ensure the VMSS will always be able to resolve addresses in the Private DNS Zone
This handles cases where the VNet has custom DNS servers set. 

## Related Issues

GDB-10042

## Changes

Added the MS internal DNS to be the default DNS for the VMSS.

## Screenshots (if applicable)

![image](https://github.com/Ontotext-AD/terraform-azure-graphdb/assets/52039166/ab5b2fb5-ae21-40be-98e5-55d3b5a19ada)

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
