### PR TITLE
Introduced ability for single node deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # GraphDB Azure Terraform Module Changelog
 
+## 1.2.0
+* Support for single node deployment:
+  * If `node_count` is 1 and multiple availability zones are specified, only the first AZ will be used.
+  * Updated Monitoring module to dynamically adjust properties based on `node_count`.
+  * Updated Gateway module to dynamically adjust properties based on `node_count`.
+  * For `node_count` of 1, no disk is created beforehand; the disk is created by the userdata scripts.
+  * Made cluster-related userdata scripts executable only when `node_count` is greater than 1.
+  * Added new userdata script `10_start_single_graphdb_services.sh.tpl` for single node setup.
+* Moved some functions to `00_functions.sh` so they are reused instead of duplicated in the userdata scripts.
+
 ## 1.1.1
 
 * Updated GraphDB version to [10.6.4](https://graphdb.ontotext.com/documentation/10.6/release-notes.html#graphdb-10-6-4)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 | gateway\_enable\_private\_access | Enable or disable private access to the application gateway | `bool` | `false` | no |
 | gateway\_enable\_private\_link\_service | Set to true to enable Private Link service, false to disable it. | `bool` | `false` | no |
 | gateway\_private\_link\_service\_network\_policies\_enabled | Enable or disable private link service network policies | `string` | `false` | no |
+| gateway\_backend\_port | Backend port for the Application Gateway rules | `number` | `7201` | no |
+| gateway\_probe\_interval | Interval in seconds between the health probe checks | `number` | `10` | no |
+| gateway\_probe\_timeout | Timeout in seconds for the health probe checks | `number` | `1` | no |
+| gateway\_probe\_threshold | Number of consecutive health checks to consider the probe passing or failing | `number` | `2` | no |
 | tls\_certificate\_path | Path to a TLS certificate that will be imported in Azure Key Vault and used in the Application Gateway TLS listener for GraphDB. | `string` | `null` | no |
 | tls\_certificate\_password | TLS certificate password for password protected certificates. | `string` | `null` | no |
 | tls\_certificate\_id | Resource identifier for a TLS certificate secret from a Key Vault. Overrides tls\_certificate\_path | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -368,6 +368,25 @@ virtual_network_name = "existing_vnet"
 Instead of using the module as dependency, you can create a local variables file named `terraform.tfvars` and provide configuration overrides there.
 Then simply follow the same steps as in the [Usage](#usage) section.
 
+## Single Node Deployment
+
+This Terraform module has the ability to deploy a single instance of GraphDB.
+To deploy a single instance you just need to set `node_count` to 1, everything else happens automatically.
+
+### Migrating from a Single Node Deployment to Cluster Deployment
+
+Here is the procedure for migrating your single node deployment to cluster e.g., from one node to 3 nodes
+
+1. Create a backup of your data.
+2. Change the `node_count` to 3 or more, depending on the cluster size you desire.
+3. Run `terraform import 'module.graphdb.azurerm_managed_disk.managed_disks[\"<DISK_NAME>\"]' /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP_NAME>/providers/Microsoft.Compute/disks/<DISK_NAME>`
+   * **IMPORTANT!** Resource names are case-sensitive and mismatch will lead to resource recreation and data loss.
+   * The CLI syntax differs depending on the OS please refer to the [documentation](https://developer.hashicorp.com/terraform/cli/commands/import).
+4. Validate the import is successful by checking the `terraform.tfstate` file, should contain `azurerm_managed_disk`
+   resource with the name of the disk you've imported.
+5. Run `terraform plan` and review the plan carefully if everything seems fine run `terraform apply`
+
+
 ## Release History
 
 All notable changes between version are tracked and documented at [CHANGELOG.md](CHANGELOG.md).

--- a/modules/gateway/main.tf
+++ b/modules/gateway/main.tf
@@ -91,8 +91,8 @@ resource "azurerm_application_gateway" "graphdb-public" {
     name = local.gateway_http_probe_name
 
     host                = "127.0.0.1"
-    path                = var.gateway_probe_path
-    port                = var.gateway_probe_port
+    path                = var.node_count != 1 ? "/rest/cluster/node/status" : "/protocol"
+    port                = var.node_count != 1 ? 7201 : 7200
     protocol            = var.gateway_backend_protocol
     interval            = var.gateway_probe_interval
     timeout             = var.gateway_probe_timeout
@@ -102,7 +102,7 @@ resource "azurerm_application_gateway" "graphdb-public" {
   backend_http_settings {
     name            = local.gateway_backend_http_settings_name
     path            = var.gateway_backend_path
-    port            = var.gateway_backend_port
+    port            = var.node_count != 1 ? 7201 : 7200
     protocol        = var.gateway_backend_protocol
     request_timeout = var.gateway_backend_request_timeout
 
@@ -255,8 +255,8 @@ resource "azurerm_application_gateway" "graphdb-private" {
     name = local.gateway_http_probe_name
 
     host                = "127.0.0.1"
-    path                = var.gateway_probe_path
-    port                = var.gateway_probe_port
+    path                = var.node_count != 1 ? "/rest/cluster/node/status" : "/protocol"
+    port                = var.node_count != 1 ? 7201 : 7200
     protocol            = var.gateway_backend_protocol
     interval            = var.gateway_probe_interval
     timeout             = var.gateway_probe_timeout
@@ -266,7 +266,7 @@ resource "azurerm_application_gateway" "graphdb-private" {
   backend_http_settings {
     name            = local.gateway_backend_http_settings_name
     path            = var.gateway_backend_path
-    port            = var.gateway_backend_port
+    port            = var.node_count != 1 ? 7201 : 7200
     protocol        = var.gateway_backend_protocol
     request_timeout = var.gateway_backend_request_timeout
 

--- a/modules/gateway/variables.tf
+++ b/modules/gateway/variables.tf
@@ -13,7 +13,6 @@ variable "location" {
 variable "zones" {
   description = "Availability zones for the public IP address."
   type        = list(number)
-  default     = [1, 2, 3]
 }
 
 variable "resource_group_name" {
@@ -74,12 +73,6 @@ variable "gateway_ssl_policy_profile" {
   default     = "AppGwSslPolicy20220101S"
 }
 
-variable "gateway_backend_port" {
-  description = "Backend port for the Application Gateway rules"
-  type        = number
-  default     = 7201
-}
-
 variable "gateway_backend_path" {
   description = "Backend path for the Application Gateway rules"
   type        = string
@@ -100,34 +93,19 @@ variable "gateway_backend_request_timeout" {
 
 # HTTP probe specifics
 
-variable "gateway_probe_path" {
-  description = "The endpoint to check for GraphDB's health status"
-  type        = string
-  default     = "/rest/cluster/node/status"
-}
-
-variable "gateway_probe_port" {
-  description = "Backend port for the health probe checks"
-  type        = number
-  default     = 7200
-}
-
 variable "gateway_probe_interval" {
   description = "Interval in seconds between the health probe checks"
   type        = number
-  default     = 10
 }
 
 variable "gateway_probe_timeout" {
   description = "Timeout in seconds for the health probe checks"
   type        = number
-  default     = 1
 }
 
 variable "gateway_probe_threshold" {
   description = "Number of consecutive health checks to consider the probe passing or failing"
   type        = number
-  default     = 2
 }
 
 # TLS certificate
@@ -178,4 +156,9 @@ variable "gateway_global_request_buffering_enabled" {
 variable "gateway_global_response_buffering_enabled" {
   description = "Whether Application Gateway's Response buffer is enabled."
   type        = bool
+}
+
+variable "node_count" {
+  description = "Number of GraphDB nodes to deploy in ASG"
+  type        = number
 }

--- a/modules/graphdb/disks.tf
+++ b/modules/graphdb/disks.tf
@@ -13,7 +13,9 @@ locals {
 
 # Creates managed disks which will be attached to the VMSS instances by the userdata script
 resource "azurerm_managed_disk" "managed_disks" {
-  for_each = {
+
+  # Do not create disks if node_count = 1 as we don't know which AZ will be the primary
+  for_each = var.node_count == 1 ? {} : {
     for entry in local.lun_map : entry.datadisk_name => entry.zone
   }
 

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "graphdb" {
   sku           = var.instance_type
   instances     = var.node_count
   zones         = var.zones
-  zone_balance  = true
+  zone_balance  = false
   upgrade_mode  = "Manual"
   overprovision = false
 

--- a/modules/graphdb/templates/00_functions.sh
+++ b/modules/graphdb/templates/00_functions.sh
@@ -10,3 +10,162 @@ log_with_timestamp() {
   fi
   echo "$(date '+%Y-%m-%d %H:%M:%S'): $1"
 }
+
+check_gdb() {
+  if [ -z "$1" ]; then
+    log_with_timestamp "Error: IP address or hostname is not provided."
+    return 1
+  fi
+
+  local gdb_address="$1:7200/rest/monitor/infrastructure"
+  if curl -s --head -u "admin:$${GRAPHDB_PASSWORD}" --fail "$gdb_address" >/dev/null; then
+    log_with_timestamp "Success, GraphDB node $gdb_address is available"
+    return 0
+  else
+    log_with_timestamp "GraphDB node $gdb_address is not available yet"
+    return 1
+  fi
+}
+
+check_all_dns_records() {
+  local DNS_ZONE_NAME="$1"
+  local RESOURCE_GROUP="$2"
+  local RETRY_DELAY="$3"
+
+  readarray -t ALL_DNS_RECORDS <<<"$(az network private-dns record-set list \
+    --zone "$DNS_ZONE_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query '[?contains(name, '\''node'\'')].fqdn' \
+    --output tsv
+  )"
+
+  for record in "$${ALL_DNS_RECORDS[@]}"; do
+    log_with_timestamp "Pinging $record"
+    # Removes the '.' at the end of the DNS address
+    cleanedAddress=$${record%?}
+    # Check if cleanedAddress is non-empty before calling check_gdb
+    if [ -n "$cleanedAddress" ]; then
+      while ! check_gdb "$cleanedAddress"; do
+        log_with_timestamp "Waiting for GDB $cleanedAddress to start"
+        sleep "$RETRY_DELAY"
+      done
+    else
+      log_with_timestamp "Error: cleanedAddress is empty."
+    fi
+  done
+
+  log_with_timestamp "All GDB instances are available. Proceeding..."
+}
+
+configure_graphdb_security() {
+  local GRAPHDB_PASSWORD=$1
+  local GRAPHDB_URL=$${2:-"http://localhost:7200"}
+
+  IS_SECURITY_ENABLED=$(curl -s -X GET \
+    --header 'Accept: application/json' \
+    -u "admin:$GRAPHDB_PASSWORD" \
+    "$${GRAPHDB_URL}/rest/security")
+
+  # Check if GDB security is enabled
+  if [[ $IS_SECURITY_ENABLED == "true" ]]; then
+    log_with_timestamp "Security is enabled"
+  else
+    # Set the admin password
+    SET_PASSWORD=$(
+      curl --location -s -w "%%{http_code}" \
+        --request PATCH "$${GRAPHDB_URL}/rest/security/users/admin" \
+        --header 'Content-Type: application/json' \
+        --data "{ \"password\": \"$GRAPHDB_PASSWORD\" }"
+    )
+    if [[ "$SET_PASSWORD" == 200 ]]; then
+      log_with_timestamp "Set GraphDB password successfully"
+    else
+      log_with_timestamp "Failed setting GraphDB password. Please check the logs!"
+    fi
+
+    # Enable the security
+    ENABLED_SECURITY=$(curl -X POST -s -w "%%{http_code}" \
+      --header 'Content-Type: application/json' \
+      --header 'Accept: */*' \
+      -d 'true' "$${GRAPHDB_URL}/rest/security")
+
+    if [[ "$ENABLED_SECURITY" == 200 ]]; then
+      log_with_timestamp "Enabled GraphDB security successfully"
+    else
+      log_with_timestamp "Failed enabling GraphDB security. Please check the logs!"
+    fi
+  fi
+}
+
+update_graphdb_admin_password() {
+  local GRAPHDB_PASSWORD="$1"
+  local GRAPHDB_ADMIN_PASSWORD="$2"
+  local RETRY_DELAY="$3"
+  local APP_CONFIGURATION_ENDPOINT="$4"
+
+  if [[ -e "/var/opt/graphdb/password_creation_time" ]]; then
+    # The request will fail if the cluster state is unhealthy
+    # This handles rolling updates
+    readarray -t ALL_DNS_RECORDS <<<"$(az network private-dns record-set list \
+      --zone "$DNS_ZONE_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --query '[?contains(name, '\''node'\'')].fqdn' \
+      --output tsv
+    )"
+    for record in "$${ALL_DNS_RECORDS[@]}"; do
+      log_with_timestamp "Pinging $record"
+      # Removes the '.' at the end of the DNS address
+      cleanedAddress=$${record%?}
+      # Check if cleanedAddress is non-empty before calling check_gdb
+      if [ -n "$cleanedAddress" ]; then
+        while ! check_gdb "$cleanedAddress"; do
+          log_with_timestamp "Waiting for GDB $cleanedAddress to start"
+          sleep "$RETRY_DELAY"
+        done
+      else
+        log_with_timestamp "Error: cleanedAddress is empty."
+      fi
+    done
+
+    # Gets the existing settings for admin user
+    EXISTING_SETTINGS=$(curl --location -s -u "admin:$GRAPHDB_PASSWORD" 'http://localhost:7200/rest/security/users/admin' | jq -rc '{grantedAuthorities, appSettings}' | sed 's/^{//;s/}$//')
+
+    SET_NEW_PASSWORD=$(
+      curl --location -s -w "%%{http_code}" \
+        --request PATCH 'http://localhost:7200/rest/security/users/admin' \
+        --header 'Content-Type: application/json' \
+        --header 'Accept: text/plain' \
+        -u "admin:$GRAPHDB_PASSWORD" \
+        --data "{\"password\":\"$GRAPHDB_ADMIN_PASSWORD\",$EXISTING_SETTINGS}"
+    )
+    if [[ "$SET_NEW_PASSWORD" == 200 ]]; then
+      log_with_timestamp "Updated GraphDB password successfully"
+      GRAPHDB_PASSWORD_CREATION_TIME="$(az appconfig kv show --endpoint $${APP_CONFIGURATION_ENDPOINT} --auth-mode login --key graphdb-password | jq -r .lastModified)"
+      echo $(date -d "$GRAPHDB_PASSWORD_CREATION_TIME" -u +"%Y-%m-%dT%H:%M:%S") > /var/opt/graphdb/password_creation_time
+    else
+      log_with_timestamp "Failed updating GraphDB password. Please check the logs!"
+      exit 1
+    fi
+  fi
+}
+
+wait_dns_records() {
+  local DNS_ZONE_NAME="$1"
+  local RESOURCE_GROUP="$2"
+  local NODE_COUNT="$3"
+
+  ALL_FQDN_RECORDS_COUNT=($(
+    az network private-dns record-set list \
+      --zone $DNS_ZONE_NAME \
+      --resource-group $RESOURCE_GROUP \
+      --query "[?contains(name, 'node')].fqdn | length(@)"
+  ))
+
+  if [ "$${ALL_FQDN_RECORDS_COUNT}" -ne "$NODE_COUNT" ]; then
+    log_with_timestamp "Expected $NODE_COUNT, found $${ALL_FQDN_RECORDS_COUNT}"
+    sleep 5
+    wait_dns_records "$DNS_ZONE_NAME" "$RESOURCE_GROUP" "$NODE_COUNT"
+  else
+    log_with_timestamp "Private DNS zone record count is $${ALL_FQDN_RECORDS_COUNT}"
+  fi
+}

--- a/modules/graphdb/templates/02_disk_management.sh.tpl
+++ b/modules/graphdb/templates/02_disk_management.sh.tpl
@@ -88,7 +88,6 @@ create_managed_disk() {
       --zone $ZONE_ID \
       --disk-iops-read-write $DISK_IOPS \
       --disk-mbps-read-write $DISK_THROUGHPUT \
-      --tags createdBy=$INSTANCE_HOSTNAME \
       --public-network-access $DISK_PUBLIC_ACCESS_POLICY \
       --network-access-policy $DISK_NETWORK_ACCESS_POLICY; then
       log_with_timestamp "Disk creation successful."

--- a/modules/graphdb/templates/09_cluster_join.sh.tpl
+++ b/modules/graphdb/templates/09_cluster_join.sh.tpl
@@ -31,16 +31,6 @@ readarray -t NODES <<<"$(az network private-dns record-set list \
   --query "[?contains(name, 'node')].name" \
   --output tsv)"
 
-check_gdb() {
-  local gdb_address="$1:7200/rest/monitor/infrastructure"
-  if curl -s --head -u "admin:$${GRAPHDB_ADMIN_PASSWORD}" --fail "$gdb_address" >/dev/null; then
-    log_with_timestamp "Success, GraphDB node $gdb_address is available"
-    return 0
-  else
-    log_with_timestamp "GraphDB node $gdb_address is not available yet"
-    return 1
-  fi
-}
 # This function should be used only after the Leader node is found
 get_cluster_state() {
   curl_response=$(curl "http://$${LEADER_NODE}/rest/monitor/cluster" -s -u "admin:$GRAPHDB_ADMIN_PASSWORD")

--- a/modules/graphdb/templates/10_start_single_graphdb_services.sh.tpl
+++ b/modules/graphdb/templates/10_start_single_graphdb_services.sh.tpl
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# This script focuses on starting GraphDB service and setting up the security in a single node deployment.
+#
+# It performs the following tasks:
+#   * Retrieves essential metadata about the Azure instance, including the instance ID, RG, DNS zone name, and GraphDB password.
+#   * Initiates GraphDB
+#   * Changes the admin user password and enables security if not already enabled.
+#   * Updates the GraphDB admin password if it has been changed in Application Config
+
+# Imports helper functions
+source /var/lib/cloud/instance/scripts/part-002
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "###########################"
+echo "#    Starting GraphDB     #"
+echo "###########################"
+
+RESOURCE_GROUP=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2021-01-01&format=text")
+DNS_ZONE_NAME=${private_dns_zone_name}
+GRAPHDB_ADMIN_PASSWORD="$(az appconfig kv show --endpoint ${app_configuration_endpoint} --auth-mode login --key graphdb-password | jq -r .value | base64 -d)"
+GRAPHDB_PASSWORD_CREATION_TIME="$(az appconfig kv show --endpoint ${app_configuration_endpoint} --auth-mode login --key graphdb-password | jq -r .lastModified)"
+
+# To update the password if changed we need to save the creation date of the config.
+# If a file is found, it will treat the password from Application config as the latest and update it.
+if [ ! -e "/var/opt/graphdb/password_creation_time" ]; then
+  # This has to be persisted
+  echo $(date -d "$GRAPHDB_PASSWORD_CREATION_TIME" -u +"%Y-%m-%dT%H:%M:%S") >/var/opt/graphdb/password_creation_time
+  GRAPHDB_PASSWORD=$GRAPHDB_ADMIN_PASSWORD
+else
+  # Gets the previous password
+  PASSWORD_CREATION_DATE=$(cat /var/opt/graphdb/password_creation_time)
+  GRAPHDB_PASSWORD="$(az appconfig kv show --endpoint ${app_configuration_endpoint} --auth-mode login --key graphdb-password --datetime $PASSWORD_CREATION_DATE | jq -r .value | base64 -d)"
+fi
+
+RETRY_DELAY=5
+
+systemctl daemon-reload
+systemctl start graphdb
+
+log_with_timestamp "Started GraphDB services"
+
+wait_dns_records "$DNS_ZONE_NAME" "$RESOURCE_GROUP" "${node_count}"
+
+check_all_dns_records "$DNS_ZONE_NAME" "$RESOURCE_GROUP" "$RETRY_DELAY"
+
+echo "###########################################################"
+echo "#    Changing admin user password and enable security     #"
+echo "###########################################################"
+
+configure_graphdb_security "$GRAPHDB_ADMIN_PASSWORD"
+
+echo "####################################"
+echo "#    Updating GraphDB password     #"
+echo "####################################"
+
+update_graphdb_admin_password "$GRAPHDB_PASSWORD" "$GRAPHDB_ADMIN_PASSWORD" "$RETRY_DELAY" "${app_configuration_endpoint}" "$${ALL_DNS_RECORDS[@]}"
+
+echo "###########################"
+echo "#    Script completed     #"
+echo "###########################"

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -1,5 +1,10 @@
 # General configurations
 
+variable "node_count" {
+  description = "Number of GraphDB nodes deployed in ASG"
+  type        = number
+}
+
 variable "resource_name_prefix" {
   description = "Resource name prefix used for tagging and naming AWS resources"
   type        = string
@@ -151,4 +156,9 @@ variable "key_vault_id" {
 variable "create_key_vault_diagnostic_settings" {
   description = "Boolean variable to determine whether to create Key Vault diagnostic settings."
   type        = bool
+}
+
+variable "graphdb_external_address_fqdn" {
+  description = "Public FQDN where GraphDB can be addressed"
+  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -148,6 +148,30 @@ variable "gateway_private_link_service_network_policies_enabled" {
   default     = false
 }
 
+variable "gateway_backend_port" {
+  description = "Backend port for the Application Gateway rules"
+  type        = number
+  default     = 7201
+}
+
+variable "gateway_probe_interval" {
+  description = "Interval in seconds between the health probe checks"
+  type        = number
+  default     = 10
+}
+
+variable "gateway_probe_timeout" {
+  description = "Timeout in seconds for the health probe checks"
+  type        = number
+  default     = 1
+}
+
+variable "gateway_probe_threshold" {
+  description = "Number of consecutive health checks to consider the probe passing or failing"
+  type        = number
+  default     = 2
+}
+
 # TLS
 variable "tls_certificate_path" {
   description = "Path to a TLS certificate that will be imported in Azure Key Vault and used in the Application Gateway TLS listener for GraphDB."
@@ -478,4 +502,3 @@ variable "notification_recipients_email_list" {
   type        = list(string)
   default     = []
 }
-


### PR DESCRIPTION
## Description

Introduced ability for single node deployment

## Related Issues

GDB-10401

## Changes

* Support for single node deployment:
  * If `node_count` is 1 and multiple availability zones are specified, only the first AZ will be used.
  * Updated Monitoring module to dynamically adjust properties based on node_count.
  * Updated Gateway module to dynamically adjust properties based on node_count.
  * For `node_count` of 1, no disk is created beforehand; the disk is created by the userdata scripts.
  * Made cluster-related userdata scripts executable only when node_count is greater than 1.
  * Added new userdata script `10_start_graphdb_services.sh.tpl` for single node setup.


## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
