### PR TITLE
Fixed the `graphdb.external-url` value when deploying a single node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # GraphDB Azure Terraform Module Changelog
 
+## 1.2.1
+
+* Fixed the `graphdb.external-url` value when deploying a single node.
+* Changed to create `graphdb-cluster-proxy/graphdb.properties` only when `node_count` > 1
+
 ## 1.2.0
+
 * Support for single node deployment:
   * If `node_count` is 1 and multiple availability zones are specified, only the first AZ will be used.
   * Updated Monitoring module to dynamically adjust properties based on `node_count`.

--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,6 @@ module "bastion" {
   bastion_allowed_inbound_address_prefixes = var.management_cidr_blocks
 }
 
-
 # Configures Azure monitoring
 module "monitoring" {
   count = var.deploy_monitoring ? 1 : 0

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -66,6 +66,7 @@ data "cloudinit_config" "entrypoint" {
     content = templatefile("${path.module}/templates/04_gdb_conf_overrides.sh.tpl", {
       graphdb_external_address_fqdn : var.graphdb_external_address_fqdn
       private_dns_zone_name : azurerm_private_dns_zone.graphdb.name
+      node_count : var.node_count
       # App configurations
       app_configuration_endpoint : var.app_configuration_endpoint
       graphdb_license_secret_name : var.graphdb_license_secret_name


### PR DESCRIPTION
## Description

Fixed the `graphdb.external-url` value when deploying a single node.

## Related Issues

GDB-10524

## Changes

* Fixed the `graphdb.external-url` value when deploying a single node.
* Changed to create `graphdb-cluster-proxy/graphdb.properties` only when `node_count` > 1

## Screenshots (if applicable)

<!-- Add any relevant screenshots or GIFs to showcase the changes visually -->

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
