### PR TITLE
Align Storage account parameters with Ontotext / Azure recommendations

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -30,8 +30,6 @@ resource "azurerm_storage_account" "graphdb_backup" {
   account_replication_type          = var.storage_account_replication_type
   enable_https_traffic_only         = true
   allow_nested_items_to_be_public   = false
-  shared_access_key_enabled         = false
-  min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
   allowed_copy_scope                = var.storage_account_allowed_copy_scope
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -28,7 +28,6 @@ resource "azurerm_storage_account" "graphdb_backup" {
   account_kind                      = var.storage_account_kind
   account_tier                      = var.storage_account_tier
   account_replication_type          = var.storage_account_replication_type
-  enable_https_traffic_only         = true
   allow_nested_items_to_be_public   = false
   infrastructure_encryption_enabled = true
   allowed_copy_scope                = var.storage_account_allowed_copy_scope


### PR DESCRIPTION
## Description

I disable two default settings (https only and minimal TLS). Worth to say that a setting for https was renamed in newer version of Azure TF provider. Also, I enable usage of SAS keys because it is the only way of recovering from cloud backups as stated here:
https://graphdb.ontotext.com/documentation/10.8/backup-and-restore.html

## Related Issues

N/A

## Changes

- removing two settings that have the same default value;
- change third to allow recover from cloud backups.

## Screenshots (if applicable)


## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
