### PR TITLE
GDB-1133 Fix handling for Monitor Reader Principal ID being null

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,14 @@ module "graphdb" {
     Environment : "dev"
   }
 
-  instance_type          = "Standard_E8as_v5"
-  graphdb_license_path   = "path-to-graphdb-license"
-  ssh_key                = "your-public-key"
-  management_cidr_blocks = ["your-ip-address"]
-  tls_certificate_path   = "path-to-your-tls-certificate"
+  instance_type            = "Standard_E8as_v5"
+  graphdb_license_path     = "path-to-graphdb-license"
+  ssh_key                  = "your-public-key"
+  management_cidr_blocks   = ["your-ip-address"]
+  tls_certificate_path     = "path-to-your-tls-certificate"
+  
+  # OPTIONAL: Required only if the password for the certificate is set
+  tls_certificate_password = "password-for-your-tls-certificate" 
 }
 ```
 
@@ -298,7 +301,9 @@ There are two options for setting up the Application Gateway with a TLS certific
 1. Provide local certificate file in PFX format with:
     ```hcl
     tls_certificate_path     = "path-to-your-tls-certificate"
-    tls_certificate_password = "tls-certificate-password"     # Optional
+    
+    # OPTIONAL: Required only if the password for the certificate is set
+    tls_certificate_password = "tls-certificate-password"
     ```
    Note: This will create a dedicated Key Vault for storing the certificate.
 2. Or provide a reference to an existing TLS certificate with:

--- a/modules/monitoring/alerts.tf
+++ b/modules/monitoring/alerts.tf
@@ -25,8 +25,8 @@ resource "azurerm_monitor_action_group" "notification_group" {
 # Role assignments
 
 resource "azurerm_role_assignment" "monitoring_reader" {
-  principal_id = var.monitor_reader_principal_id
-  # TODO test this out, not sure if this is the proper scope
+  count                = var.monitor_reader_principal_id != null ? 1 : 0
+  principal_id         = var.monitor_reader_principal_id
   scope                = azurerm_application_insights.graphdb_insights.id
   role_definition_name = "Monitoring Reader"
 }

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -118,6 +118,7 @@ variable "web_test_timeout" {
 variable "monitor_reader_principal_id" {
   description = "Principal(Object) ID of a user/group which would receive notifications from alerts."
   type        = string
+  default     = null
 }
 
 variable "ag_notifications_email_list" {


### PR DESCRIPTION
## Description

In this pull request, I have implemented a bug fix to conditionally create the azurerm_role_assignment resource based on the value of monitor_reader_principal_id.

## Related Issues

GitHub issue: #99 
Internal Jira Issue: [GDB-11331](https://ontotext.atlassian.net/browse/GDB-11331)

## Changes

Added a conditional expression using the [count](https://developer.hashicorp.com/terraform/language/meta-arguments/count) meta-argument to ensure the azurerm_role_assignment resource is only created if monitor_reader_principal_id is not null.

## Screenshots (if applicable)

No

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11331]: https://ontotext.atlassian.net/browse/GDB-11331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ