### PR TITLE
Changes to the run backup script configuration

### DIFF
--- a/modules/graphdb/templates/05_gdb_backup_conf.sh.tpl
+++ b/modules/graphdb/templates/05_gdb_backup_conf.sh.tpl
@@ -20,16 +20,24 @@ echo "#################################################"
 cat <<EOF >/usr/bin/run_backup.sh
 #!/bin/bash
 
+storage_account="\$1"
+storage_container="\$2"
+
 az login --identity
 
 # Extract GraphDB password from Azure App Configuration
-graphdb_password="\$(az appconfig kv show --endpoint ${app_configuration_endpoint} --auth-mode login --key graphdb-password | jq -r .value | base64 -d)"
+graphdb_password="\$(az appconfig kv show \
+  --endpoint ${app_configuration_endpoint} \
+  --auth-mode login \
+  --key graphdb-password \
+  | jq -r .value \
+  | base64 -d)"
 
-/usr/bin/graphdb_backup admin \$${graphdb_password} ${backup_storage_account_name} ${backup_storage_container_name}
+/usr/bin/graphdb_backup admin "\$${graphdb_password}" "\$${storage_account}" "\$${storage_container}"
 
 EOF
 
 chmod +x /usr/bin/run_backup.sh
-echo "${backup_schedule}" graphdb /usr/bin/run_backup.sh >/etc/cron.d/graphdb_backup
+echo "${backup_schedule} graphdb /usr/bin/run_backup.sh ${backup_storage_account_name} ${backup_storage_container_name}" > /etc/cron.d/graphdb_backup
 
 log_with_timestamp "Cron job created"

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,8 +17,3 @@ output "public_ip_address" {
   description = "The public IP address of the application gateway"
   value       = var.disable_agw ? null : module.application_gateway[0].public_ip_address
 }
-
-output "app_configuration_endpoint" {
-  description = "Endpoint of the App Configuration store for GraphDB"
-  value       = module.appconfig.app_configuration_endpoint
-}


### PR DESCRIPTION
## Description
* Changed the run backup script to accept storage account and container as variables instead of being hardcoded.
* Removed output `app_configuration_endpoint` as it's not used.

## Related Issues

N/A

## Changes

* Changed the run backup script to accept storage account and container as variables instead of being hardcoded.
* Removed output `app_configuration_endpoint` as it's not used.

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
