### PR TITLE
Removed duplicated public_address output in outputs.tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added wait condition for DNS Records and nodes
 * Fixed handling for Monitor Reader Principal ID being null
 * Updated `run_backup.sh` so that the storage account name and container name are passed as script arguments.
+* Fixed duplicated public IP address in outputs.tf
 
 ## 1.4.2
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,3 @@ output "public_address" {
   )
 }
 
-output "public_ip_address" {
-  description = "The public IP address of the application gateway"
-  value       = var.disable_agw ? null : module.application_gateway[0].public_ip_address
-}


### PR DESCRIPTION
## Description

Removed duplicated public_address output in outputs.tf

## Changes

Removed duplicated public_address output in outputs.tf

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
