### PR TITLE
[GDB-11597]Update the terraform module to set the private frontend IP as a external FQDN and update provider version

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,68 +2,62 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.91.0"
-  constraints = "~> 3.91.0"
+  version     = "4.17.0"
+  constraints = "~> 4.17.0"
   hashes = [
-    "h1:8hMFuaTQsZIV69D0J/W+6hSlhRRDzYSpC0Eg9yWYF0o=",
-    "h1:LagYfbO2xfkGMMisggbfFMbVZd00ZPYnOVGig+935e0=",
-    "h1:t0I5G4canK6UdlgHGfMV4rUNBPGdrMiIB01VGizlXB8=",
-    "zh:13928b71b1235783f3f877a799e28fb91e50512b051eb8ccb370500fc140cf3f",
-    "zh:3264341657e9ff3963d69b0fa088f64665349e2a29b2f3aeb4deee6d9d7584b7",
-    "zh:467a2ddd2eee26353db65e949bfbe533481ca0fb53c152724380b63a308f11b9",
-    "zh:6133e57087167b163180df3a77fab0c63b3e11609d139d39db8d3be3d6ec7ccd",
-    "zh:6df24730bc9247647ffb44832c3c64e45ab731dd83a3592d33d28235a453235a",
-    "zh:775aae148223a4a86e2dd25533a95a5fea4817085b6c5e643a7192453270cd68",
-    "zh:89d51148c7c123685d3e2f7e291888a3af009656e5c0ad66235a7c686ecb19d2",
-    "zh:9c89552051226eeb7c0fc66ad5aa57d1d0f5acc1d56afad06b6596707ae6c85e",
-    "zh:c4f3bc269837fa3b6ad803de2c7d1125dd791d78a521dcad2e7a63b905a13a53",
-    "zh:e48f05de1ffdcc998c5ff915570fb0557c7ac1d3af971dd76aff82e66d45bf06",
-    "zh:f1945716c7b9c23c25ca9fb4a68f27b6cfa25f5d235112c31f9412eba47f93c6",
+    "h1:VgnUh7PiRa/76P+0NFk8vmrmfLnPT6+tOZ/AP6h4TeQ=",
+    "zh:163b81a3bf29c8f161a1c100a48164b1bd1af434cd564b44596cb71a6c33f03d",
+    "zh:2996b107d3c05a9db14458b32b6f22f8cde0adb96263196d82d3dc302907a257",
+    "zh:361abd84b6e73016ebebb9ef9cd14c237d8b1e4500ea75f73243ff0534e5e4fb",
+    "zh:4872445dcb109fe8bbaba439d3dffaaef849a92645df3f8a854d3a40ac962f68",
+    "zh:61974eb7379acadbceb47b001ae1de2cdefe8cf078a15fff3a6fcc753cd24273",
+    "zh:75c60ca6e7851fe1d52fe9f5a0ae3d219e300ee5aa63bc8f807e3e0cab569ff0",
+    "zh:7c79305cff7849e6c5d9d60fe570510f95fb2e2bd5ae801da0281702f21dd779",
+    "zh:964b7da03f2dc55583cda3c277fef3511824b183a3a88344ae4ff9823af79109",
+    "zh:cad1593d364eb22b68578a1da4fd4d84749dc81f20e6591b27c6cb1eed9d2072",
+    "zh:db1a2ca17aae78813e8e0676bb9ef941e1a1e32d9fc6e1b239c24661605a8425",
+    "zh:e3a65d2f6f5a63cd1beeeb60a23e7e6b7328ebbd46ffe994792aaac6738186c3",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/cloudinit" {
-  version     = "2.3.4"
+  version     = "2.3.5"
   constraints = "~> 2.3.3"
   hashes = [
-    "h1:S3j8poSaLbaftlKq2STBkQEkZH253ZLaHhBHBifdpBQ=",
-    "h1:cVIIhnXweOHavu1uV2bdKScTjLbM1WnKM/25wqYBJWo=",
-    "h1:iDq03pOzp/UsXya2h+32VOOrvGdJgI9L2/EZJoN9t4A=",
-    "zh:09f1f1e1d232da96fbf9513b0fb5263bc2fe9bee85697aa15d40bb93835efbeb",
-    "zh:381e74b90d7a038c3a8dcdcc2ce8c72d6b86da9f208a27f4b98cabe1a1032773",
-    "zh:398eb321949e28c4c5f7c52e9b1f922a10d0b2b073b7db04cb69318d24ffc5a9",
-    "zh:4a425679614a8f0fe440845828794e609b35af17db59134c4f9e56d61e979813",
-    "zh:4d955d8608ece4984c9f1dacda2a59fdb4ea6b0243872f049b388181aab8c80a",
+    "h1:Sf1Lt21oTADbzsnlU38ylpkl8YXP0Beznjcy5F/Yx64=",
+    "zh:17c20574de8eb925b0091c9b6a4d859e9d6e399cd890b44cfbc028f4f312ac7a",
+    "zh:348664d9a900f7baf7b091cf94d657e4c968b240d31d9e162086724e6afc19d5",
+    "zh:5a876a468ffabff0299f8348e719cb704daf81a4867f8c6892f3c3c4add2c755",
+    "zh:6ef97ee4c8c6a69a3d36746ba5c857cf4f4d78f32aa3d0e1ce68f2ece6a5dba5",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:a48fbee1d58d55a1f4c92c2f38c83a37c8b2f2701ed1a3c926cefb0801fa446a",
-    "zh:b748fe6631b16a1dafd35a09377c3bffa89552af584cf95f47568b6cd31fc241",
-    "zh:d4b931f7a54603fa4692a2ec6e498b95464babd2be072bed5c7c2e140a280d99",
-    "zh:f1c9337fcfe3a7be39d179eb7986c22a979cfb2c587c05f1b3b83064f41785c5",
-    "zh:f58fc57edd1ee3250a28943cd84de3e4b744cdb52df0356a53403fc240240636",
-    "zh:f5f50de0923ff530b03e1bca0ac697534d61bb3e5fc7f60e13becb62229097a9",
+    "zh:8283e5a785e3c518a440f6ac6e7cc4fc07fe266bf34974246f4e2ef05762feda",
+    "zh:a44eb5077950168b571b7eb65491246c00f45409110f0f172cc3a7605f19dba9",
+    "zh:aa0806cbff72b49c1b389c0b8e6904586e5259c08dabb7cb5040418568146530",
+    "zh:bec4613c3beaad9a7be7ca99cdb2852073f782355b272892e6ee97a22856aec1",
+    "zh:d7fe368577b6c8d1ae44c751ed42246754c10305c7f001cc0109833e95aa107d",
+    "zh:df2409fc6a364b1f0a0f8a9cd8a86e61e80307996979ce3790243c4ce88f2915",
+    "zh:ed3c263396ff1f4d29639cc43339b655235acf4d06296a7c120a80e4e0fd6409",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.6.2"
+  version     = "3.6.3"
   constraints = "~> 3.6.0"
   hashes = [
-    "h1:Gd3WitYIzSYo/Suo+PMxpZpIGpRPrwl0JU0+DhxycFM=",
-    "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
-    "h1:wmG0QFjQ2OfyPy6BB7mQ57WtoZZGGV07uAPQeDmIrAE=",
-    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
-    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
-    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
-    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
-    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
-    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
-    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
-    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
-    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
-    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
   ]
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 * Updated `run_backup.sh` so that the storage account name and container name are passed as script arguments.
 * Fixed duplicated public IP address in outputs.tf
 * Added ability to provide user_supplied_rendered_templates and user_supplied_templates to the VMSS instances
+* Added check if node count is greater than 1 to use /rest/cluster/node/status health endpoint if not, use /protocol
+* Added ability to use private IP as a FQDN if the application gateway is deployed in private mode
+* Updated AzureRM provider to version 4.17
+* Changed storage_account_name to storage_account_id in modules/backup/main.tf since it will be removed in version 5.0 of the Provider.
+* Removed enable_https_only in modules/backup/main.tf since it is not supported anymore since v4.x of the AzureRM Provider.
+* Updated AzureMonitorLinuxAgent extension for the VMSS to from 1.0 to 1.33
+* Added fix for VMSS scale up
+* Removed min_tls_version since now defaults to 1_2
 
 ## 1.4.2
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| azure\_subscription\_id | Define Subscription ID for authentication (Required) | `string` | `""` | no |
 | resource\_group\_name | The name of the existing resource group to use. If not provided, a new resource group will be created. | `string` | `null` | no |
 | virtual\_network\_name | The name of the existing vnet to use. If not provided, a new virtual network will be created. | `string` | `null` | no |
 | resource\_name\_prefix | Resource name prefix used for tagging and naming Azure resources | `string` | n/a | yes |
@@ -200,6 +201,12 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 
 ## Usage
 
+**Important:** Starting from **v4.x** of the **AzureRM Terraform provider**, it's mandatory to specify the **Subscription ID** to ensure successful module deployment. You can define the **Subscription ID** in terraform.tfvars file:
+
+```hcl
+azure_subscription_id = "XXXXX-XXXXX-XXXXX-XXXXX"
+```
+
 To use the GraphDB module, create a new Terraform project or add to an existing one the following module block:
 
 ```hcl
@@ -207,21 +214,24 @@ module "graphdb" {
   source  = "Ontotext-AD/graphdb/azure"
   version = "~> 1.0"
 
-  resource_name_prefix = "graphdb"
-  location             = "East US"
-  zones                = [1, 2, 3]
-  tags                 = {
-    Environment : "dev"
+  resource_name_prefix       = "graphdb"
+  location                   = "East US"
+  zones                      = [1, 2, 3]
+
+  tags = {
+    Environment = "dev"
   }
 
-  instance_type            = "Standard_E8as_v5"
-  graphdb_license_path     = "path-to-graphdb-license"
-  ssh_key                  = "your-public-key"
-  management_cidr_blocks   = ["your-ip-address"]
-  tls_certificate_path     = "path-to-your-tls-certificate"
+  instance_type              = "Standard_E8as_v5"
+  graphdb_license_path       = "path-to-graphdb-license"
+  ssh_key                    = "your-public-key"
+  management_cidr_blocks     = ["your-ip-address"]
+  tls_certificate_path       = "path-to-your-tls-certificate"
+  # Mandatory since version 4.x of the AzureRM Provider
+  azure_subscription_id      = "XXXXX-XXXXX-XXXXX-XXXXX"
 
   # OPTIONAL: Required only if the password for the certificate is set
-  tls_certificate_password = "password-for-your-tls-certificate"
+  tls_certificate_password   = "password-for-your-tls-certificate"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -260,11 +260,11 @@ module "monitoring" {
   location             = var.location
   node_count           = var.node_count
 
-  web_test_availability_request_url = var.disable_agw ? var.graphdb_external_address_fqdn : module.application_gateway[0].public_ip_address_fqdn
+  web_test_availability_request_url = var.graphdb_external_address_fqdn != null ? var.graphdb_external_address_fqdn : (var.gateway_enable_private_access ? module.application_gateway[0].private_ip_address : (var.disable_agw ? null : module.application_gateway[0].public_ip_address_fqdn))
   web_test_geo_locations            = var.web_test_geo_locations
   web_test_ssl_check_enabled        = var.web_test_ssl_check_enabled
 
-  graphdb_external_address_fqdn = var.graphdb_external_address_fqdn != null ? var.graphdb_external_address_fqdn : module.application_gateway[0].public_ip_address_fqdn
+  graphdb_external_address_fqdn = var.graphdb_external_address_fqdn != null ? var.graphdb_external_address_fqdn : (var.gateway_enable_private_access ? module.application_gateway[0].private_ip_address : (var.disable_agw ? null : module.application_gateway[0].public_ip_address_fqdn))
 
   monitor_reader_principal_id = var.monitor_reader_principal_id
 
@@ -283,6 +283,7 @@ module "monitoring" {
   app_configuration_id                 = module.appconfig.app_configuration_id
   key_vault_id                         = var.tls_certificate_id != null ? null : module.vault[0].key_vault_id
   create_key_vault_diagnostic_settings = var.tls_certificate_id == null ? true : false
+  gateway_enable_private_access        = var.gateway_enable_private_access
 }
 
 locals {
@@ -318,12 +319,13 @@ module "graphdb" {
   app_configuration_endpoint = module.appconfig.app_configuration_endpoint
 
   # GraphDB Configurations
-  graphdb_external_address_fqdn = var.graphdb_external_address_fqdn != null ? var.graphdb_external_address_fqdn : (var.disable_agw ? null : module.application_gateway[0].public_ip_address_fqdn)
-  graphdb_password              = var.graphdb_password
-  graphdb_license_path          = var.graphdb_license_path
-  graphdb_cluster_token         = var.graphdb_cluster_token
-  graphdb_properties_path       = var.graphdb_properties_path
-  graphdb_java_options          = var.graphdb_java_options
+  graphdb_external_address_fqdn = var.graphdb_external_address_fqdn != null ? var.graphdb_external_address_fqdn : (var.gateway_enable_private_access ? module.application_gateway[0].private_ip_address : (var.disable_agw ? null : module.application_gateway[0].public_ip_address_fqdn))
+
+  graphdb_password        = var.graphdb_password
+  graphdb_license_path    = var.graphdb_license_path
+  graphdb_cluster_token   = var.graphdb_cluster_token
+  graphdb_properties_path = var.graphdb_properties_path
+  graphdb_java_options    = var.graphdb_java_options
 
   # Backups Storage Account
   backup_storage_account_name   = module.backup.storage_account_name

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -16,22 +16,20 @@ locals {
   trimmed = lower(substr("st${local.sanitized}", 0, 18))
 
   # Create storage account name with unique suffix and a maximum of 24 characters
-  storage_account_name = "${local.trimmed}${random_string.storage_account_name_suffix.result}"
+  storage_account_id = "${local.trimmed}${random_string.storage_account_name_suffix.result}"
 }
 
 # Create an Azure Storage Account for backups
 resource "azurerm_storage_account" "graphdb_backup" {
-  name                = local.storage_account_name
+  name                = local.storage_account_id
   resource_group_name = var.resource_group_name
   location            = var.location
 
   account_kind                      = var.storage_account_kind
   account_tier                      = var.storage_account_tier
   account_replication_type          = var.storage_account_replication_type
-  enable_https_traffic_only         = true
   allow_nested_items_to_be_public   = false
   shared_access_key_enabled         = false
-  min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
   allowed_copy_scope                = var.storage_account_allowed_copy_scope
 
@@ -58,7 +56,7 @@ resource "azurerm_storage_account" "graphdb_backup" {
 # Create an Azure Storage container
 resource "azurerm_storage_container" "graphdb_backup" {
   name                  = "${var.resource_name_prefix}-backup"
-  storage_account_name  = azurerm_storage_account.graphdb_backup.name
+  storage_account_id    = azurerm_storage_account.graphdb_backup.id
   container_access_type = "private"
 }
 

--- a/modules/gateway/outputs.tf
+++ b/modules/gateway/outputs.tf
@@ -20,6 +20,11 @@ output "public_ip_address_fqdn" {
   value       = azurerm_public_ip.graphdb_public_ip_address.fqdn
 }
 
+output "private_ip_address" {
+  description = "The private IPv4 address"
+  value       = var.gateway_enable_private_access ? azurerm_application_gateway.graphdb-private[0].frontend_ip_configuration[1].private_ip_address : ""
+}
+
 # Gateway
 
 output "gateway_id" {

--- a/modules/graphdb/main.tf
+++ b/modules/graphdb/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "graphdb" {
     name                       = "ConsulHealthExtension"
     publisher                  = "Microsoft.ManagedServices"
     type                       = "ApplicationHealthLinux"
-    type_handler_version       = "2.0"
+    type_handler_version       = "1.0"
     auto_upgrade_minor_version = false
 
     settings = jsonencode({
@@ -78,7 +78,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "graphdb" {
   # Explicitly setting instance repair to false.
   # Re-creating a GraphDB instance would not solve any issues in most cases.
   automatic_instance_repair {
-    enabled = false
+    enabled      = false
+    grace_period = "PT10M" # Even though it is optional, if not specified the deployment crashes
   }
 
   scale_in {

--- a/modules/monitoring/availability_tests.tf
+++ b/modules/monitoring/availability_tests.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 resource "azurerm_application_insights_standard_web_test" "at-cluster-health" {
-  enabled = var.appi_web_test_availability_enabled
+  count = var.appi_web_test_availability_enabled && !var.gateway_enable_private_access ? 1 : 0
 
   name                    = "at-${var.resource_name_prefix}-cluster-health"
   resource_group_name     = var.resource_group_name

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -163,3 +163,8 @@ variable "graphdb_external_address_fqdn" {
   description = "Public FQDN where GraphDB can be addressed"
   type        = string
 }
+
+variable "gateway_enable_private_access" {
+  description = "Enable or disable private access to the application gateway"
+  type        = bool
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,22 @@
 output "public_address" {
   description = "Public address for GraphDB"
-  value = var.disable_agw ? (
-    # If disable_agw is true, use graphdb_external_address_fqdn with context_path if set
-    "https://${coalesce(var.graphdb_external_address_fqdn, "")}${length(var.context_path) > 0 ? "/${trim(var.context_path, "/")}" : ""}/"
-    ) : (
-    # If disable_agw is false, check context_path
-    length(var.context_path) > 0 ?
-    # If context_path has content, use application_gateway with context_path
-    "https://${module.application_gateway[0].public_ip_address_fqdn}/${trim(var.context_path, "/")}/" :
-    # If context_path is empty, use application_gateway without path
-    "https://${module.application_gateway[0].public_ip_address_fqdn}/"
+  value = var.gateway_enable_private_access ? null : (
+    var.disable_agw ? (
+      # If disable_agw is true, use graphdb_external_address_fqdn with context_path if set
+      "https://${coalesce(var.graphdb_external_address_fqdn, "")}${length(var.context_path) > 0 ? "/${trim(var.context_path, "/")}" : ""}/"
+      ) : (
+      # If disable_agw is false, check context_path
+      length(var.context_path) > 0 ?
+      # If context_path has content, use application_gateway with context_path
+      "https://${module.application_gateway[0].public_ip_address_fqdn}/${trim(var.context_path, "/")}/" :
+      # If context_path is empty, use application_gateway without path
+      "https://${module.application_gateway[0].public_ip_address_fqdn}/"
+    )
   )
 }
 
+
+output "private_ip_address" {
+  description = "The Private IPv4 address for accessing GraphDB via the Application Gateway"
+  value       = var.gateway_enable_private_access ? module.application_gateway[0].private_ip_address : null
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = var.azure_subscription_id
   features {
     managed_disk {
       expand_without_downtime = true

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,11 @@
 # General configurations
 
+variable "azure_subscription_id" {
+  description = "Define Subscription ID for authentication (Required)"
+  type        = string
+  default     = ""
+}
+
 variable "resource_group_name" {
   description = "The name of the existing resource group to use. If not provided, a new resource group will be created."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,9 @@
 terraform {
-  required_version = "~>1.7"
-
+  required_version = "~>1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.91.0"
+      version = "~>4.17.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description

- Updated AzureRM provider to version 4.17
- Added changes regarding the provider update
- Added changes to output private_ip_address of the Application Gateway when deployed in private mode.
- Updated CHANGELOG.md
- Changed storage_account_name to storage_account_id in modules/backup/main.tf since it will be removed in version 5.0 of the Provider.
-  Updated AzureMonitorLinuxAgent extension for the VMSS to from 1.0 to 1.33
- Disabled availability tests in the monitoring module if Application Gateway is deployed in private mode.

## Related Issues

[GDB-11597]

## Changes

- Updated AzureRM provider to version 4.17
- Added changes regarding the provider update
- Added changes to output private_ip_address of the Application Gateway when deployed in private mode.
- Updated CHANGELOG.md
- Changed storage_account_name to storage_account_id in modules/backup/main.tf since it will be removed in version 5.0 of the Provider.
-  Updated AzureMonitorLinuxAgent extension for the VMSS to from 1.0 to 1.33
- Disabled availability tests in the monitoring module if Application Gateway is deployed in private mode.

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.


[GDB-11597]: https://ontotext.atlassian.net/browse/GDB-11597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ