### PR TITLE
[GDB-11815] Remove read/write permissions on /etc/telegraf directory

### DIFF
--- a/modules/graphdb/templates/06_telegraf_conf.sh.tpl
+++ b/modules/graphdb/templates/06_telegraf_conf.sh.tpl
@@ -35,6 +35,8 @@ cat <<-EOF >/etc/telegraf/telegraf.conf
     region = "$REGION_ID"
     resource_id = "$RESOURCE_ID"
 EOF
+# Prevent any other user (except root) from reading the telegraf config. Apply recursively for entire dir
+chmod -R og-rwx /etc/telegraf
 
 systemctl restart telegraf
 


### PR DESCRIPTION
## Description

Prevents users (other from root) from reading telegraf configuration files. This is to prevent users from reading the GDB admin password, stored in the config file. 

## Related Issues

[GDB-11815](https://ontotext.atlassian.net/browse/GDB-11815)

## Changes

Sets the access permissions for the `/etc/telegraf` directory to only allow read-write by root

## Checklist

- [ ] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11815]: https://ontotext.atlassian.net/browse/GDB-11815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ