### PR TITLE
[GDB-11814] Remove sudoers.d/90-cloud-init-users

### DIFF
--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -116,7 +116,7 @@ if [[ $secrets == *"${graphdb_java_options_secret_name}"* ]]; then
   log_with_timestamp "Using GDB_JAVA_OPTS overrides"
   extra_graphdb_java_options=$(az appconfig kv show --endpoint "$APP_CONFIG_ENDPOINT" --auth-mode login --key ${graphdb_java_options_secret_name} | jq -r .value | base64 -d)
   if grep GDB_JAVA_OPTS &>/dev/null /etc/graphdb/graphdb.env; then
-    sed -ie "s/GDB_JAVA_OPTS=\"\(.*\)\"/GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"/g" /etc/graphdb/graphdb.env
+    sed -ie "s|GDB_JAVA_OPTS=\"\(.*\)\"|GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"|g" /etc/graphdb/graphdb.env
   else
     echo "GDB_JAVA_OPTS=$extra_graphdb_java_options" > /etc/graphdb/graphdb.env
   fi

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -122,4 +122,8 @@ if [[ $secrets == *"${graphdb_java_options_secret_name}"* ]]; then
   fi
 fi
 
+# Remove sudo privileges for all local users - they don't need this permission and is a high security risk
+log_with_timestamp "Re-configure user permissions"
+[[ -f /etc/sudoers.d/90-cloud-init-users ]] && rm /etc/sudoers.d/90-cloud-init-users
+
 log_with_timestamp "Completed applying overrides"

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -121,9 +121,4 @@ if [[ $secrets == *"${graphdb_java_options_secret_name}"* ]]; then
     echo "GDB_JAVA_OPTS=$extra_graphdb_java_options" > /etc/graphdb/graphdb.env
   fi
 fi
-
-# Remove sudo privileges for all local users - they don't need this permission and is a high security risk
-log_with_timestamp "Re-configure user permissions"
-[[ -f /etc/sudoers.d/90-cloud-init-users ]] && rm /etc/sudoers.d/90-cloud-init-users
-
 log_with_timestamp "Completed applying overrides"

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -178,4 +178,12 @@ data "cloudinit_config" "entrypoint" {
       content      = templatefile(part.value["path"], part.value["variables"])
     }
   }
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = <<-EOF
+        #!/bin/bash
+        [[ -f /etc/sudoers.d/90-cloud-init-users ]] && rm /etc/sudoers.d/90-cloud-init-users
+      EOF
+  }
 }


### PR DESCRIPTION
## Description

Removes /etc/sudoers.d/90-cloud-init-users to remove sudo capability from graphdb and packer users

## Related Issues

[GDB-11814](https://ontotext.atlassian.net/browse/GDB-11814)

## Changes

Removes /etc/sudoers.d/90-cloud-init-users


## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11814]: https://ontotext.atlassian.net/browse/GDB-11814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ