### PR TITLE
[GDB-11833] Parse /etc/graphdb/graphdb.env and modify GDB_JAVA_OPTS inline

### DIFF
--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -110,10 +110,11 @@ fi
 if [[ $secrets == *"${graphdb_java_options_secret_name}"* ]]; then
   log_with_timestamp "Using GDB_JAVA_OPTS overrides"
   extra_graphdb_java_options=$(az appconfig kv show --endpoint "$APP_CONFIG_ENDPOINT" --auth-mode login --key ${graphdb_java_options_secret_name} | jq -r .value | base64 -d)
-  (
-  source /etc/graphdb/graphdb.env
-  echo "GDB_JAVA_OPTS=\"$GDB_JAVA_OPTS $extra_graphdb_java_options\"" >>/etc/graphdb/graphdb.env
-  )
+  if grep GDB_JAVA_OPTS &>/dev/null /etc/graphdb/graphdb.env; then
+    sed -ie "s/GDB_JAVA_OPTS=\"\(.*\)\"/GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"/g" /etc/graphdb/graphdb.env
+  else
+    echo "GDB_JAVA_OPTS=$extra_graphdb_java_options" > /etc/graphdb/graphdb.env
+  fi
 fi
 
 log_with_timestamp "Completed applying overrides"


### PR DESCRIPTION
## Description

Parses GDB_JAVA_OPTS variable from /etc/graphdb/graphdb.env, instead of source the file

## Related Issues
[GDB-11833](https://ontotext.atlassian.net/browse/GDB-11833)

## Changes
Changes `04_gdb_conf_overrides.sh.tpl` to parse `/etc/graphdb/graphdb.env` and modify GDB_JAVA_OPTS inline  

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.


[GDB-11833]: https://ontotext.atlassian.net/browse/GDB-11833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ