### PR TITLE
Reorder grep check

### DIFF
--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -110,7 +110,7 @@ fi
 if [[ $secrets == *"${graphdb_java_options_secret_name}"* ]]; then
   log_with_timestamp "Using GDB_JAVA_OPTS overrides"
   extra_graphdb_java_options=$(az appconfig kv show --endpoint "$APP_CONFIG_ENDPOINT" --auth-mode login --key ${graphdb_java_options_secret_name} | jq -r .value | base64 -d)
-  if grep GDB_JAVA_OPTS &>/dev/null /etc/graphdb/graphdb.env; then
+  if grep GDB_JAVA_OPTS /etc/graphdb/graphdb.env &>/dev/null ; then
     sed -ie "s/GDB_JAVA_OPTS=\"\(.*\)\"/GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"/g" /etc/graphdb/graphdb.env
   else
     echo "GDB_JAVA_OPTS=$extra_graphdb_java_options" > /etc/graphdb/graphdb.env


### PR DESCRIPTION
## Description

Fixes an invalid `grep` check in `04_gdb_conf_overrides.sh.tpl`. Regressions introduced in https://github.com/Ontotext-AD/terraform-aws-graphdb/pull/82

## Related Issues

[GDB-11623](https://ontotext.atlassian.net/browse/GDB-11623)

## Changes

- Fixes the reordering of `grep` logic to check if `GDB_JAVA_OPTS` is set.

## Checklist

- [ ] I have tested these changes thoroughly.
- [ ] My code follows the project's coding style.
- [ ] I have added appropriate comments to my code, especially in complex areas.
- [ ] All new and existing tests passed locally.


[GDB-11623]: https://ontotext.atlassian.net/browse/GDB-11623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ