### PR TITLE
[GDB-12121] Changed the user data scripts so they don't trigger a refresh during scale out

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 4.17.0"
   hashes = [
     "h1:VgnUh7PiRa/76P+0NFk8vmrmfLnPT6+tOZ/AP6h4TeQ=",
+    "h1:YJLbnnB0F9blm99LgcvbmgxoixE80M5xVh5XVJbdexM=",
     "zh:163b81a3bf29c8f161a1c100a48164b1bd1af434cd564b44596cb71a6c33f03d",
     "zh:2996b107d3c05a9db14458b32b6f22f8cde0adb96263196d82d3dc302907a257",
     "zh:361abd84b6e73016ebebb9ef9cd14c237d8b1e4500ea75f73243ff0534e5e4fb",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   constraints = "~> 2.3.3"
   hashes = [
     "h1:Sf1Lt21oTADbzsnlU38ylpkl8YXP0Beznjcy5F/Yx64=",
+    "h1:wbw64JlCobcQCAdlzHpxksQ1GabewTW1yxnACBVZh4A=",
     "zh:17c20574de8eb925b0091c9b6a4d859e9d6e399cd890b44cfbc028f4f312ac7a",
     "zh:348664d9a900f7baf7b091cf94d657e4c968b240d31d9e162086724e6afc19d5",
     "zh:5a876a468ffabff0299f8348e719cb704daf81a4867f8c6892f3c3c4add2c755",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.3"
   constraints = "~> 3.6.0"
   hashes = [
+    "h1:N2IQabOiZC5eCEGrfgVS6ChVmRDh1ENtfHgGjnV4QQQ=",
     "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 
 ## Usage
 
-**Important:** Starting from **v4.x** of the **AzureRM Terraform provider**, it's mandatory to specify the **Subscription ID** to ensure successful module deployment. You can define the **Subscription ID** in terraform.tfvars file:
+**Important:** Starting from **v4.x** of the **AzureRM Terraform provider**,
+it's mandatory to specify the **Subscription ID** to ensure successful module deployment.
+You can define the **Subscription ID** in `terraform.tfvars` file:
 
 ```hcl
 azure_subscription_id = "XXXXX-XXXXX-XXXXX-XXXXX"
@@ -469,6 +471,11 @@ Here is the procedure for migrating your single node deployment to cluster e.g.,
 4. Validate the import is successful by checking the `terraform.tfstate` file, should contain `azurerm_managed_disk`
    resource with the name of the disk you've imported.
 5. Run `terraform plan` and review the plan carefully if everything seems fine run `terraform apply`
+
+## Scaling out a cluster
+
+To expand your cluster—increasing the `node_count` from 3 to 5 or beyond, simply modify the `node_count` parameter
+and execute `terraform apply`.
 
 
 ## Release History

--- a/modules/graphdb/config.tf
+++ b/modules/graphdb/config.tf
@@ -56,3 +56,10 @@ resource "azurerm_app_configuration_key" "graphdb_java_options" {
   value                  = base64encode(var.graphdb_java_options)
   content_type           = "text/plain"
 }
+
+resource "azurerm_app_configuration_key" "graphdb_node_count" {
+  configuration_store_id = var.app_configuration_id
+  key                    = var.node_count_name
+  value                  = var.node_count
+  content_type           = "text/plain"
+}

--- a/modules/graphdb/templates/01_wait_resources.sh.tpl
+++ b/modules/graphdb/templates/01_wait_resources.sh.tpl
@@ -23,9 +23,14 @@ PRIVATE_DNS_ZONE_LINK_ID="${private_dns_zone_link_id}"
 APP_CONFIGURATION_ENDPOINT="${app_configuration_endpoint}"
 APP_CONFIGURATION_ID="${app_configuration_id}"
 STORAGE_ACCOUNT_NAME=${storage_account_name}
-GRAPHDB_NODE_COUNT=${node_count}
 VMSS_NAME=${vmss_name}
 RESOURCE_GROUP=${resource_group}
+GRAPHDB_NODE_COUNT="$(az appconfig kv show \
+  --endpoint ${app_configuration_endpoint} \
+  --auth-mode login \
+  --key node_count \
+  | jq -r .value)"
+
 
 # Only run the wait_vmss_nodes function if graphdb_node_count is more than 1
 if [ "$GRAPHDB_NODE_COUNT" -gt 1 ]; then

--- a/modules/graphdb/templates/08_cluster_setup.sh.tpl
+++ b/modules/graphdb/templates/08_cluster_setup.sh.tpl
@@ -28,6 +28,11 @@ DNS_ZONE_NAME=${private_dns_zone_name}
 GRAPHDB_ADMIN_PASSWORD="$(az appconfig kv show --endpoint ${app_configuration_endpoint} --auth-mode login --key graphdb-password | jq -r .value | base64 -d)"
 GRAPHDB_PASSWORD_CREATION_TIME="$(az appconfig kv show --endpoint ${app_configuration_endpoint} --auth-mode login --key graphdb-password | jq -r .lastModified)"
 VMSS_NAME=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/vmScaleSetName?api-version=2021-01-01&format=text")
+GRAPHDB_NODE_COUNT="$(az appconfig kv show \
+  --endpoint ${app_configuration_endpoint} \
+  --auth-mode login \
+  --key node_count \
+  | jq -r .value)"
 
 # To update the password if changed we need to save the creation date of the config.
 # If a file is found, it will treat the password from Application config as the latest and update it.
@@ -95,7 +100,7 @@ if [ "$INSTANCE_ID" == "$${LOWEST_INSTANCE_ID}" ]; then
   echo "#    Beginning cluster setup     #"
   echo "##################################"
 
-  wait_dns_records "$DNS_ZONE_NAME" "$RESOURCE_GROUP" "${node_count}"
+  wait_dns_records "$DNS_ZONE_NAME" "$RESOURCE_GROUP" "$GRAPHDB_NODE_COUNT"
   check_all_dns_records "$DNS_ZONE_NAME" "$RESOURCE_GROUP" "$RETRY_DELAY"
 
   for ((i = 1; i <= $MAX_RETRIES; i++)); do

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -35,7 +35,6 @@ data "cloudinit_config" "entrypoint" {
       app_configuration_endpoint : var.app_configuration_endpoint
       app_configuration_id : var.app_configuration_id
       storage_account_name : var.backup_storage_account_name
-      node_count : var.node_count
       vmss_name : "vmss-${var.resource_name_prefix}"
       resource_group : var.resource_group_name
     })
@@ -73,7 +72,6 @@ data "cloudinit_config" "entrypoint" {
     content = templatefile("${path.module}/templates/04_gdb_conf_overrides.sh.tpl", {
       graphdb_external_address_fqdn : var.graphdb_external_address_fqdn
       private_dns_zone_name : azurerm_private_dns_zone.graphdb.name
-      node_count : var.node_count
       # App configurations
       app_configuration_endpoint : var.app_configuration_endpoint
       graphdb_license_secret_name : var.graphdb_license_secret_name
@@ -127,7 +125,6 @@ data "cloudinit_config" "entrypoint" {
       content = templatefile("${path.module}/templates/08_cluster_setup.sh.tpl", {
         app_configuration_endpoint : var.app_configuration_endpoint
         private_dns_zone_name : azurerm_private_dns_zone.graphdb.name
-        node_count : var.node_count
       })
     }
   }
@@ -151,7 +148,6 @@ data "cloudinit_config" "entrypoint" {
       content = templatefile("${path.module}/templates/10_start_single_graphdb_services.sh.tpl", {
         app_configuration_endpoint : var.app_configuration_endpoint
         private_dns_zone_name : azurerm_private_dns_zone.graphdb.name
-        node_count : var.node_count
       })
     }
   }

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -195,6 +195,12 @@ variable "graphdb_image_id" {
 
 # GraphDB VM
 
+variable "node_count_name" {
+  description = "Name for the node_count property in App Configuration"
+  type        = string
+  default     = "node_count"
+}
+
 variable "node_count" {
   description = "Number of GraphDB nodes to deploy in ASG"
   type        = number


### PR DESCRIPTION
## Description
Changed the user data scripts so they don't trigger a refresh on existing cluster nodes when scaling out, preventing downtime.

## Related Issues

GDB-12121 

## Changes

Added a new property in Application config named `node_count` and changed the user data scripts to read the node count from it. 
As a result scaling from 1 to 3 nodes works as expected, scaling from 3 to 5 or more nodes does not introduce downtime.

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
