### PR TITLE
Create backup user home directory, otherwise az cli fails

### DIFF
--- a/modules/graphdb/templates/05_gdb_backup_conf.sh.tpl
+++ b/modules/graphdb/templates/05_gdb_backup_conf.sh.tpl
@@ -19,7 +19,7 @@ echo "#################################################"
 
 echo "Creating the backup user"
 echo "Creating the backup user"
-useradd -r -M -s /usr/sbin/nologin gdb-backup
+useradd -r -m -s /usr/sbin/nologin gdb-backup
 
 cat <<EOF >/usr/bin/run_backup.sh
 #!/bin/bash


### PR DESCRIPTION
## Description

Fixes gdb-backup backup user

## Related Issues

[https://graphwise.atlassian.net/browse/GDB-11816](GDB-11816)

## Changes

Fix to gdb-backup user creation - create home directory (need by `az-cli`)

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
