### PR TITLE
Added variable for setting the Application Gateway Public IP idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Azure Terraform Module Changelog
 
+## 2.1.0
+
+* Added ability to provide `idle_timeout_in_minutes` for the Application Gateway Public IP
+* Added ability to provide `idle_timeout_in_minutes` for the NAT Gateway Public IP
+* Removed obsolete variable `gateway_backend_port` since the backend port is now automatically set based on the `node_count`
+
 ## 2.0.2
 
 * Update default GraphDB version to [11.0.2](https://graphdb.ontotext.com/documentation/11.0/release-notes.html#graphdb-11-0-2)

--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 | disable\_agw | Disables the creation of Application Gateway by the Terraform module. | `bool` | `false` | no |
 | gateway\_enable\_private\_link\_service | Set to true to enable Private Link service, false to disable it. | `bool` | `false` | no |
 | gateway\_private\_link\_service\_network\_policies\_enabled | Enable or disable private link service network policies | `string` | `false` | no |
-| gateway\_backend\_port | Backend port for the Application Gateway rules | `number` | `7201` | no |
 | gateway\_probe\_interval | Interval in seconds between the health probe checks | `number` | `10` | no |
 | gateway\_probe\_timeout | Timeout in seconds for the health probe checks | `number` | `1` | no |
 | gateway\_probe\_threshold | Number of consecutive health checks to consider the probe passing or failing | `number` | `2` | no |
+| app\_gateway\_pip\_idle\_timeout | TCP Idle timeout in minutes for the client connection to the Application Gateway Public IP | `number` | `4` | no |
 | context\_path | The context path for the Application Gateway. | `string` | `""` | no |
+| nat\_gateway\_pip\_idle\_timeout | TCP Idle timeout in minutes for the client connection to the NAT Gateway Public IP | `number` | `4` | no |
 | tls\_certificate\_path | Path to a TLS certificate that will be imported in Azure Key Vault and used in the Application Gateway TLS listener for GraphDB. Either tls\_certificate\_path or tls\_certificate\_id must be provided. | `string` | `null` | no |
 | tls\_certificate\_password | TLS certificate password for password-protected certificates. | `string` | `null` | no |
 | tls\_certificate\_id | Resource identifier for a TLS certificate secret from a Key Vault. Overrides tls\_certificate\_path. Either tls\_certificate\_id or tls\_certificate\_path must be provided. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -217,6 +217,9 @@ module "application_gateway" {
   disable_agw  = var.disable_agw
   context_path = var.context_path
 
+  # Public IP idle timeout settings
+  gateway_pip_idle_timeout = var.app_gateway_pip_idle_timeout
+
   # TLS
   gateway_tls_certificate_secret_id   = var.tls_certificate_id != null ? var.tls_certificate_id : module.tls[0].tls_certificate_id
   gateway_tls_certificate_identity_id = var.tls_certificate_id != null ? var.tls_certificate_identity_id : module.tls[0].tls_identity_id
@@ -308,6 +311,9 @@ module "graphdb" {
   graphdb_ssh_inbound_address_prefixes = var.deploy_bastion ? var.bastion_subnet_address_prefixes : []
   graphdb_outbound_address_prefix      = var.outbound_allowed_address_prefix
   graphdb_outbound_address_prefixes    = var.outbound_allowed_address_prefixes
+
+  # Public IP idle timeout settings
+  nat_gateway_pip_idle_timeout = var.nat_gateway_pip_idle_timeout
 
   # Gateway
   application_gateway_backend_address_pool_ids = var.disable_agw ? [] : [module.application_gateway[0].gateway_backend_address_pool_id]

--- a/modules/gateway/variables.tf
+++ b/modules/gateway/variables.tf
@@ -152,9 +152,8 @@ variable "gateway_private_link_service_network_policies_enabled" {
 # Public IP configurations
 
 variable "gateway_pip_idle_timeout" {
-  description = "Specifies the timeout for the TCP idle connection"
+  description = "TCP idle timeout in minutes for the Application Gateway Public IP"
   type        = number
-  default     = 5
 }
 
 # Proxy buffer configurations

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -300,9 +300,8 @@ variable "scaleset_actions_recipients_email_list" {
 # Public IP configurations
 
 variable "nat_gateway_pip_idle_timeout" {
-  description = "Specifies the timeout for the TCP idle connection"
+  description = "TCP idle timeout in minutes for the NAT Gateway Public IP"
   type        = number
-  default     = 5
 }
 
 # Customer provided user data scripts

--- a/variables.tf
+++ b/variables.tf
@@ -160,12 +160,6 @@ variable "gateway_private_link_service_network_policies_enabled" {
   default     = false
 }
 
-variable "gateway_backend_port" {
-  description = "Backend port for the Application Gateway rules"
-  type        = number
-  default     = 7201
-}
-
 variable "gateway_probe_interval" {
   description = "Interval in seconds between the health probe checks"
   type        = number
@@ -184,10 +178,34 @@ variable "gateway_probe_threshold" {
   default     = 2
 }
 
+variable "app_gateway_pip_idle_timeout" {
+  description = "TCP Idle timeout in minutes for the client connection to the Application Gateway Public IP"
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.app_gateway_pip_idle_timeout >= 4 && var.app_gateway_pip_idle_timeout <= 30
+    error_message = "Application Gateway Public IP idle timeout should be between 4 and 30 minutes (inclusive)"
+  }
+}
+
 variable "context_path" {
   description = "The context path for the Application Gateway."
   type        = string
   default     = ""
+}
+
+# NAT Gateway
+
+variable "nat_gateway_pip_idle_timeout" {
+  description = "TCP Idle timeout in minutes for the client connection to the NAT Gateway Public IP"
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.nat_gateway_pip_idle_timeout >= 4 && var.nat_gateway_pip_idle_timeout <= 30
+    error_message = "NAT Gateway Public IP idle timeout should be between 4 and 30 minutes (inclusive)"
+  }
 }
 
 # TLS
@@ -227,6 +245,7 @@ variable "key_vault_soft_delete_retention_days" {
   description = "Retention period in days during which soft deleted secrets are kept"
   type        = number
   default     = 30
+
   validation {
     condition     = var.key_vault_soft_delete_retention_days >= 7 && var.key_vault_soft_delete_retention_days <= 90
     error_message = "Key Vault soft delete retention days must be between 7 and 90 (inclusive)"
@@ -245,6 +264,7 @@ variable "app_config_soft_delete_retention_days" {
   description = "Retention period in days during which soft deleted keys are kept"
   type        = number
   default     = 7
+
   validation {
     condition     = var.app_config_soft_delete_retention_days >= 1 && var.app_config_soft_delete_retention_days <= 7
     error_message = "App Configuration soft delete retention days must be between 1 and 7 (inclusive)"
@@ -380,6 +400,7 @@ variable "storage_container_soft_delete_retention_policy" {
   description = "Number of days for retaining the storage container from actual deletion"
   type        = number
   default     = 31
+
   validation {
     condition     = var.storage_container_soft_delete_retention_policy >= 1 && var.storage_container_soft_delete_retention_policy <= 365
     error_message = "Storage container soft delete retention days must be between 1 and 365 (inclusive)"
@@ -390,6 +411,7 @@ variable "storage_blob_soft_delete_retention_policy" {
   description = "Number of days for retaining storage blobs from actual deletion"
   type        = number
   default     = 31
+
   validation {
     condition     = var.storage_blob_soft_delete_retention_policy >= 1 && var.storage_blob_soft_delete_retention_policy <= 365
     error_message = "Storage blobs soft delete retention days must be between 1 and 365 (inclusive)"


### PR DESCRIPTION
Added configurable option  **app_gateway_pip_idle_timeout** that allows manipulation of the frontend public IP (PIP) timeout for the Azure Application Gateway and **nat_gateway_pip_idle_timeout** that allows manipulation of the frontend public IP (PIP) timeout for the Azure NAT Gateway.

## Checklist

- [✅] I have tested these changes thoroughly.
- [✅] My code follows the project's coding style.
- [✅] I have added appropriate comments to my code, especially in complex areas.
- [✅] All new and existing tests passed locally.
