### PR TITLE
Added support for Jump VM to access the GraphDB instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GraphDB Azure Terraform Module Changelog
 
+## 3.1.0
+
+* Added Jump VM module (`jumpvm`) for direct SSH access to GraphDB nodes as a lightweight, fast-provisioning alternative to Azure Bastion
+
 ## 3.0.1
 
 * Updated GraphDB default version to [11.3.2](https://graphdb.ontotext.com/documentation/11.3/release-notes.html#graphdb-11-3-2)

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 | bastion\_subnet\_address\_prefixes | Bastion subnet address prefixes | `list(string)` | ```[ "10.0.3.0/26" ]``` | no |
 | deploy\_jump\_vm | Deploy a Jump VM for direct SSH access to GraphDB nodes. Faster alternative to Azure Bastion. | `bool` | `false` | no |
 | jump\_subnet\_address\_prefixes | Subnet address prefixes for the Jump VM | `list(string)` | ```[ "10.0.4.0/24" ]``` | no |
-| jump\_vm\_size | Azure VM SKU for the Jump VM | `string` | `"Standard_B2s"` | no |
-| jump\_vm\_admin\_username | Admin username for the Jump VM | `string` | `"adminuser"` | no |
+| jump\_vm\_sku | Azure VM SKU for the Jump VM | `string` | `"Standard_B1s"` | no |
+| jump\_vm\_admin\_username | Admin username for the Jump VM | `string` | `"graphdb"` | no |
 | deploy\_monitoring | Deploy monitoring module | `bool` | `true` | no |
 | disk\_size\_gb | Size of the managed data disk which will be created | `number` | `500` | no |
 | disk\_iops\_read\_write | Data disk IOPS | `number` | `7500` | no |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ zones using a VM scale set. Key features of the module include:
 - Azure Private DNS for internal GraphDB cluster communication
 - Azure Key Vault for storing sensitive configurations
 - Optional Azure Bastion deployment
+- Optional Jump VM deployment for direct SSH access to GraphDB nodes
 - User assigned identities for RBAC authorization with the least privilege principle
 - and more
 
@@ -65,6 +66,7 @@ zones using a VM scale set. Key features of the module include:
 | TLS Module                 | Manages TLS certificate secrets in Key Vault and their related identities.                                        | - Creates TLS certificate secrets in Key Vault.<br/> - Configures identity related to the TLS certificate.                                                        |
 | Application Gateway Module | Sets up a public IP address and Application Gateway for forwarding internet traffic to GraphDB proxies/instances. | - Configures TLS certificate for the gateway.<br/> - Enables private access and private link service.<br/> - Defines global buffer settings.                      |
 | Bastion Module             | Deploys an Azure Bastion host for secure remote connections.                                                      | - Configures the bastion host within the specified virtual network.                                                                                               |
+| Jump VM Module             | Deploys a lightweight Linux VM with a public IP for direct SSH access to GraphDB nodes.                          | - Faster to provision than Azure Bastion.<br/> - Configurable VM size and admin username.<br/> - NSG restricts SSH inbound to `management_cidr_blocks` only.     |
 | Monitoring Module          | Configures Azure monitoring for the deployed resources.                                                           | - Sets up Application Insights for the GraphDB scale set.<br/> - Sets up web test availability monitoring.<br/> - Defines retention policies for monitoring data. |
 | GraphDB Module             | Deploys a VM scale set for GraphDB and its cluster proxies.                                                       | - Configures networking settings.<br/> - Sets up GraphDB configurations and licenses.<br/> - Defines backup storage, VM image, and managed disk settings.         |
 
@@ -187,6 +189,10 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 | backup\_schedule | Cron expression for the backup job. | `string` | `"0 0 * * *"` | no |
 | deploy\_bastion | Deploy bastion module | `bool` | `false` | no |
 | bastion\_subnet\_address\_prefixes | Bastion subnet address prefixes | `list(string)` | ```[ "10.0.3.0/26" ]``` | no |
+| deploy\_jump\_vm | Deploy a Jump VM for direct SSH access to GraphDB nodes. Faster alternative to Azure Bastion. | `bool` | `false` | no |
+| jump\_subnet\_address\_prefixes | Subnet address prefixes for the Jump VM | `list(string)` | ```[ "10.0.4.0/24" ]``` | no |
+| jump\_vm\_size | Azure VM SKU for the Jump VM | `string` | `"Standard_B2s"` | no |
+| jump\_vm\_admin\_username | Admin username for the Jump VM | `string` | `"adminuser"` | no |
 | deploy\_monitoring | Deploy monitoring module | `bool` | `true` | no |
 | disk\_size\_gb | Size of the managed data disk which will be created | `number` | `500` | no |
 | disk\_iops\_read\_write | Data disk IOPS | `number` | `7500` | no |
@@ -323,6 +329,30 @@ To enable the deployment of Azure Bastion, you simply need to enable the followi
 
 ```hcl
 deploy_bastion = true
+```
+
+**Jump VM**
+
+To enable a Jump VM for direct SSH access to GraphDB nodes, set:
+
+```hcl
+deploy_jump_vm = true
+ssh_key        = "your-public-key"
+```
+
+The Jump VM uses the same `ssh_key` as the GraphDB nodes and is reachable on port 22 from your `management_cidr_blocks`.
+After `terraform apply`, use the `jump_vm_ssh_command` output to connect:
+
+```bash
+ssh adminuser@<jump_vm_public_ip>
+```
+
+From the Jump VM you can then SSH into any GraphDB node by its private IP. You can customise the VM size and subnet:
+
+```hcl
+jump_vm_sku                  = "Standard_B2s"
+jump_vm_admin_username       = "adminuser"
+jump_subnet_address_prefixes = ["10.0.4.0/24"]
 ```
 
 **Public Gateway with Private Link**

--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,25 @@ module "bastion" {
   bastion_allowed_inbound_address_prefixes = var.management_cidr_blocks
 }
 
+# Creates a Jump VM for direct SSH access to GraphDB nodes
+module "jumpvm" {
+  count = var.deploy_jump_vm ? 1 : 0
+
+  source = "./modules/jumpvm"
+
+  resource_name_prefix = var.resource_name_prefix
+  location             = var.location
+  resource_group_name  = local.resource_group_name
+
+  virtual_network_name            = local.virtual_network_name
+  jump_subnet_address_prefixes    = var.jump_subnet_address_prefixes
+  graphdb_subnet_address_prefixes = var.graphdb_subnet_address_prefixes
+  allowed_ssh_cidr_blocks         = var.management_cidr_blocks
+  vm_sku                          = var.jump_vm_sku
+  admin_username                  = var.jump_vm_admin_username
+  ssh_key                         = var.ssh_key
+}
+
 # Configures Azure monitoring
 module "monitoring" {
   count = var.deploy_monitoring ? 1 : 0
@@ -263,12 +282,15 @@ module "graphdb" {
   zones                = local.adjusted_zones
 
   # Networking
-  virtual_network_id                   = local.virtual_network_id
-  graphdb_subnet_id                    = azurerm_subnet.graphdb_vmss.id
-  graphdb_inbound_address_prefixes     = var.gateway_subnet_address_prefixes
-  graphdb_ssh_inbound_address_prefixes = var.deploy_bastion ? var.bastion_subnet_address_prefixes : []
-  graphdb_outbound_address_prefix      = var.outbound_allowed_address_prefix
-  graphdb_outbound_address_prefixes    = var.outbound_allowed_address_prefixes
+  virtual_network_id               = local.virtual_network_id
+  graphdb_subnet_id                = azurerm_subnet.graphdb_vmss.id
+  graphdb_inbound_address_prefixes = var.gateway_subnet_address_prefixes
+  graphdb_ssh_inbound_address_prefixes = concat(
+    var.deploy_bastion ? var.bastion_subnet_address_prefixes : [],
+    var.deploy_jump_vm ? var.jump_subnet_address_prefixes : []
+  )
+  graphdb_outbound_address_prefix   = var.outbound_allowed_address_prefix
+  graphdb_outbound_address_prefixes = var.outbound_allowed_address_prefixes
 
   # Public IP idle timeout settings
   nat_gateway_pip_idle_timeout = var.nat_gateway_pip_idle_timeout

--- a/modules/jumpvm/main.tf
+++ b/modules/jumpvm/main.tf
@@ -1,0 +1,134 @@
+#
+# Jump VM — lightweight SSH proxy into the GraphDB VMSS subnet
+#
+
+resource "azurerm_subnet" "jumpvm" {
+  name                 = "snet-${var.resource_name_prefix}-jumpvm"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = var.virtual_network_name
+  address_prefixes     = var.jump_subnet_address_prefixes
+}
+
+resource "azurerm_network_security_group" "jumpvm" {
+  name                = "nsg-${var.resource_name_prefix}-jumpvm"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  security_rule {
+    name                       = "AllowSSHInBound"
+    description                = "Allows SSH from management CIDR blocks"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_address_prefixes    = var.allowed_ssh_cidr_blocks
+    source_port_range          = "*"
+    destination_address_prefix = "*"
+    destination_port_range     = "22"
+  }
+
+  security_rule {
+    name                       = "DenyInBound"
+    description                = "Denies any other inbound traffic"
+    priority                   = 4096
+    direction                  = "Inbound"
+    access                     = "Deny"
+    protocol                   = "*"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_address_prefix = "*"
+    destination_port_range     = "*"
+  }
+
+  security_rule {
+    name                         = "AllowSSHToGraphDB"
+    description                  = "Allows SSH from Jump VM to GraphDB VMSS subnet"
+    priority                     = 100
+    direction                    = "Outbound"
+    access                       = "Allow"
+    protocol                     = "Tcp"
+    source_address_prefix        = "*"
+    source_port_range            = "*"
+    destination_address_prefixes = var.graphdb_subnet_address_prefixes
+    destination_port_range       = "22"
+  }
+
+  security_rule {
+    name                       = "AllowInternetOutBound"
+    description                = "Allows outbound internet access for package installs and updates"
+    priority                   = 200
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_address_prefix = "Internet"
+    destination_port_ranges    = ["80", "443"]
+  }
+
+  security_rule {
+    name                       = "DenyOutBound"
+    description                = "Denies any other outbound traffic"
+    priority                   = 4096
+    direction                  = "Outbound"
+    access                     = "Deny"
+    protocol                   = "*"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_address_prefix = "*"
+    destination_port_range     = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "jumpvm" {
+  network_security_group_id = azurerm_network_security_group.jumpvm.id
+  subnet_id                 = azurerm_subnet.jumpvm.id
+}
+
+resource "azurerm_public_ip" "jumpvm" {
+  name                = "pip-${var.resource_name_prefix}-jumpvm"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_network_interface" "jumpvm" {
+  name                = "nic-${var.resource_name_prefix}-jumpvm"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.jumpvm.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.jumpvm.id
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "jumpvm" {
+  name                = "vm-${var.resource_name_prefix}-jumpvm"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  size                = var.vm_sku
+  admin_username      = var.admin_username
+
+  network_interface_ids = [azurerm_network_interface.jumpvm.id]
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = var.ssh_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+}

--- a/modules/jumpvm/outputs.tf
+++ b/modules/jumpvm/outputs.tf
@@ -1,0 +1,14 @@
+output "public_ip_address" {
+  description = "Public IP address of the Jump VM"
+  value       = azurerm_public_ip.jumpvm.ip_address
+}
+
+output "private_ip_address" {
+  description = "Private IP address of the Jump VM"
+  value       = azurerm_network_interface.jumpvm.private_ip_address
+}
+
+output "subnet_address_prefixes" {
+  description = "Address prefixes of the Jump VM subnet"
+  value       = azurerm_subnet.jumpvm.address_prefixes
+}

--- a/modules/jumpvm/variables.tf
+++ b/modules/jumpvm/variables.tf
@@ -1,0 +1,46 @@
+variable "resource_name_prefix" {
+  description = "Resource name prefix used for naming Azure resources"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure geographical location where resources will be deployed"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group where the Jump VM will be deployed"
+  type        = string
+}
+
+variable "virtual_network_name" {
+  description = "Virtual network where the Jump VM will be deployed"
+  type        = string
+}
+
+variable "jump_subnet_address_prefixes" {
+  description = "Address prefixes for the Jump VM subnet"
+  type        = list(string)
+  default     = ["10.0.4.0/24"]
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "CIDR blocks permitted to SSH into the Jump VM"
+  type        = list(string)
+}
+
+variable "graphdb_subnet_address_prefixes" {
+  description = "Address prefixes of the GraphDB VMSS subnet (used to allow outbound SSH)"
+  type        = list(string)
+}
+
+variable "admin_username" {
+  description = "Admin username for the Jump VM"
+  type        = string
+  default     = "adminuser"
+}
+
+variable "ssh_key" {
+  description = "Public SSH key for authenticating to the Jump VM"
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,3 +49,13 @@ output "dns_cname_records" {
   description = "CNAME records created in the DNS zone (if any)"
   value       = var.deploy_external_dns_records && length(module.external_dns_records[0].cname_records) > 0 ? module.external_dns_records[0].cname_records : null
 }
+
+output "jump_vm_public_ip_address" {
+  description = "Public IP address of the Jump VM for SSH access (null if not deployed)"
+  value       = var.deploy_jump_vm ? module.jumpvm[0].public_ip_address : null
+}
+
+output "jump_vm_ssh_command" {
+  description = "SSH command to connect to the Jump VM (null if not deployed)"
+  value       = var.deploy_jump_vm ? "ssh -i <path_to_private_key> ${var.jump_vm_admin_username}@${module.jumpvm[0].public_ip_address}" : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -446,6 +446,32 @@ variable "bastion_subnet_address_prefixes" {
   default     = ["10.0.3.0/26"]
 }
 
+# Jump VM
+
+variable "deploy_jump_vm" {
+  description = "Deploy a Jump VM for direct SSH access to GraphDB nodes. Faster alternative to Azure Bastion."
+  type        = bool
+  default     = false
+}
+
+variable "jump_subnet_address_prefixes" {
+  description = "Subnet address prefixes for the Jump VM"
+  type        = list(string)
+  default     = ["10.0.4.0/24"]
+}
+
+variable "jump_vm_sku" {
+  description = "Azure VM SKU for the Jump VM"
+  type        = string
+  default     = "Standard_B1s"
+}
+
+variable "jump_vm_admin_username" {
+  description = "Admin username for the Jump VM"
+  type        = string
+  default     = "graphdb"
+}
+
 # Monitoring
 
 variable "deploy_monitoring" {


### PR DESCRIPTION
## Description

This PR adds support for a Jump VM (bastion host) to enable secure access to the GraphDB instances.

## Related Issues

[GDB-14346]

## Changes

* Added Jump VM configuration to allow SSH tunneling to GraphDB nodes
* Updated security group rules to allow inbound access from the Jump VM
* Updated network configuration to route traffic through the Jump VM

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.


[GDB-14346]: https://graphwise.atlassian.net/browse/GDB-14346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ