### PR TITLE
Fixed the proxy port in the GDB config overrides.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GraphDB Azure Terraform Module Changelog
 
+## 3.1.1
+
+* Fixed the proxy port in the GDB config overrides.
+
 ## 3.1.0
 
 * Updated GraphDB default version to [11.3.3](https://graphdb.ontotext.com/documentation/11.3/release-notes.html#graphdb-11-3-3)

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -65,8 +65,10 @@ else
 
 if [ -n "${context_path}" ]; then
   VHOSTS_VALUE="https://${graphdb_external_address_fqdn}/$${CLEAN_CONTEXT_PATH},http://$${NODE_DNS}:7200"
+  PROXY_VHOSTS_VALUE="https://${graphdb_external_address_fqdn}/$${CLEAN_CONTEXT_PATH},http://$${NODE_DNS}:7201"
 else
   VHOSTS_VALUE="https://${graphdb_external_address_fqdn},http://$${NODE_DNS}:7200"
+  PROXY_VHOSTS_VALUE="https://${graphdb_external_address_fqdn},http://$${NODE_DNS}:7201"
 fi
 
 cat <<EOF >/etc/graphdb/graphdb.properties
@@ -86,7 +88,7 @@ fi
 cat <<EOF >/etc/graphdb-cluster-proxy/graphdb.properties
 graphdb.auth.token.secret=$graphdb_cluster_token
 graphdb.connector.port=7201
-graphdb.vhosts=$${VHOSTS_VALUE}
+graphdb.vhosts=$${PROXY_VHOSTS_VALUE}
 graphdb.external-url=$${EXTERNAL_URL}
 graphdb.rpc.address=$${NODE_DNS}:7301
 graphdb.proxy.hosts=$${NODE_DNS}:7300


### PR DESCRIPTION
## Description

Fixed the proxy port in the GDB config overrides.

## Related Issues

N/A

## Changes

Switched port 7200 to 7201 for vhosts in the proxy graphdb.properties.

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
