### PR TITLE
Updates the version of the GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,11 @@ jobs:
     steps:
       - id: clone_repository
         name: Clone repository
-        # actions/checkout@v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: setup_terraform
         name: Setup Terraform CLI
-        # hashicorp/setup-terraform@v3.0.0
-        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - id: run_terraform_init
         name: Run Terraform init
@@ -40,7 +38,7 @@ jobs:
 
       - id: run_trivy_config
         name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           trivy-config: trivy.yaml
@@ -51,8 +49,7 @@ jobs:
 
       - id: run_sarif_upload
         name: Upload Trivy SARIF results
-        # github/codeql-action/upload-sarif@v2.22.9
-        uses: github/codeql-action/upload-sarif@382a50a0284c0de445104889a9d6003acb4b3c1d
+        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a #v2.25.4
         timeout-minutes: 1
         with:
           sarif_file: trivy.sarif

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,15 +11,13 @@ jobs:
     steps:
       - id: clone_repository
         name: Clone repository
-        # actions/checkout@v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - id: run_terraform_docs
         name: Render terraform docs and push changes back to PR
-        # terraform-docs/gh-actions@1.0.0
-        uses: terraform-docs/gh-actions@f6d59f89a280fa0a3febf55ef68f146784b20ba0
+        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
         with:
           working-dir: .
           output-file: README.md

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,10 @@
 # Rule: Key vault should have purge protection enabled
 # Note: There is a variable for controlling the purge protection
 AVD-AZU-0016
+
 # Storage account does not have logging enabled for any service.
 AVD-AZU-0057
+
+# Storage account with blob containers should use customer-managed keys for encryption.
+# Reason: Disabled until implemented
+AZU-0060


### PR DESCRIPTION
- There are actions using NodeJS v20 images. These are deprecated and soon will be removed. To keep the actions in working condition and up-to-date, we've updated all actions to their latest version that is currently available.
