### PR TITLE
Add encryption at rest

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,8 +5,6 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.49.0"
   constraints = "~> 4.49.0"
   hashes = [
-    "h1:JTDto1UqD0/FyT448oZxl8bNCP9UB2DglVKErWgeWPQ=",
-    "h1:pWWO78O03ILOsJS8U3eFGf4DYgPET9F06ptsUE5/sqU=",
     "h1:vZLqK4w0lXyVnAlbkJM0FzQUdXvRsFxF+LXBlzbbOlw=",
     "zh:20ca02cb78c6936be685c1e5b10a3aaf2a9e623abb36aba239e5b95a41f24695",
     "zh:4c4b0d893cdb3f135d37a99710cf21fccd7d27f312935a9feb3aabae1fb70a2b",
@@ -27,9 +25,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.7"
   constraints = "~> 2.3.3"
   hashes = [
-    "h1:h1Pr6uNwq+iDEGrnQJEHzOTz+yVTW0AJgZrGXuoO4Qs=",
     "h1:iZ27qylcH/2bs685LJTKOKcQ+g7cF3VwN3kHMrzm4Ow=",
-    "h1:rafNPmTutVTO2Horq45DG9Pjqrs+vx42oc7b/3aVGEc=",
     "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
     "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
     "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
@@ -49,10 +45,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.3"
   constraints = "~> 3.6.0"
   hashes = [
-    "h1:+UItZOLue/moJfnI3tqZBQbXUYR4ZnqPYfJDJPgLZy0=",
     "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
-    "h1:N2IQabOiZC5eCEGrfgVS6ChVmRDh1ENtfHgGjnV4QQQ=",
-    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
     "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
@@ -73,9 +66,6 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.10.0"
   hashes = [
     "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
-    "h1:NAl8eupFAZXCAbE5uiHZTz+Yqler55B3fMG+jNPrjjM=",
-    "h1:XiRMsGFEe6VTWGL0O32l8viW2fI8wXyJFRJYfdQR8os=",
-    "h1:rPbqd7mEyBetQPjyBDBAdwiARulKbh2LwzQp2GSl/AI=",
     "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
     "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",
     "zh:3bbb3e9da728b82428c6f18533b5b7c014e8ff1b8d9b2587107c966b985e5bcc",

--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 | m2m\_app\_registration\_client\_id | The M2M App registration client ID | `string` | `null` | no |
 | m2m\_app\_registration\_client\_secret | The M2M App registration client secret | `string` | `null` | no |
 | m2m\_scope | The scope for the M2M application | `string` | `null` | no |
+| graphdb\_data\_encryption\_type | The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12 | `string` | `""` | no |
+| graphdb\_data\_encryption\_master\_key\_filepath | The master key, when using file-based data encryption. | `string` | `""` | no |
+| graphdb\_data\_encryption\_keystore\_alias | The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12) | `string` | n/a | yes |
+| graphdb\_data\_encryption\_keystore\_filepath | Local path to a keystore file containing the master key for encryption at rest setup | `string` | `""` | no |
+| graphdb\_data\_encryption\_keystore\_password | The keystore password for the data encryption keystore (when using type pkcs12) | `string` | `""` | no |
 <!-- END_TF_DOCS -->
 
 ## Usage
@@ -502,6 +507,42 @@ graphdb_audit_log_max_request_length = 1024
 ```
 
 See [GraphDB Security Auditing](https://graphdb.ontotext.com/documentation/11.4/security-auditing.html) for more details.
+
+
+**Encryption at Rest**
+
+Starting from 11.4.0, GraphDB supports encryption at rest (See [here](https://graphdb.ontotext.com/documentation/11.4/encryption.html#encryption-at-rest)). There are two ways to configure encryption at rest: master key and pkcs12 keystore
+
+***Using a master key***
+
+To configure encryption at rest using a master key, the following variables can be set:
+
+```hcl
+graphdb_data_encryption_type              = "pkcs12"
+graphdb_data_encryption_master_key_filepath = "/path/to/local/master.txt"
+```
+where the `master.txt` contains the 256 bit master key. An example of creating a master key is shown below:
+
+```hcl
+$ head -c 32 /dev/urandom
+```
+
+***Using PKCS12 keystore***
+
+To configure encryption at rest using a PKCS12 keystore, first create a keystore with a secret key. Example is shown below:
+
+```hcl
+$ keytool -importpass -alias <key_alias> -keyalg AES -keysize 256 -keystore /path/to/keystore -storetype PKCS12
+```
+Then configure and deploy as such:
+
+```hcl
+graphdb_data_encryption_type              = "pkcs12"
+graphdb_data_encryption_keystore_password = "<pass>"
+graphdb_data_encryption_keystore_alias    = "<key_alias>"
+graphdb_data_encryption_keystore_filepath = "/path/to/keystore"
+```
+where `pass` is the keystore password and `key_alias` is the key alias inside the keystore.
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ az vm image terms accept --offer graphdb-ee --plan graphdb-byol --publisher onto
 | m2m\_scope | The scope for the M2M application | `string` | `null` | no |
 | graphdb\_data\_encryption\_type | The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12 | `string` | `""` | no |
 | graphdb\_data\_encryption\_master\_key\_filepath | The master key, when using file-based data encryption. | `string` | `""` | no |
-| graphdb\_data\_encryption\_keystore\_alias | The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12) | `string` | n/a | yes |
+| graphdb\_data\_encryption\_master\_key\_secret\_name | Name for the graphdb\_data\_encryption\_master\_key\_filepath property in App Configuration | `string` | `"graphdb_data_encryption_master_key_filepath"` | no |
+| graphdb\_data\_encryption\_keystore\_alias | The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12) | `string` | `"masterkey"` | no |
+| graphdb\_data\_encryption\_keystore\_secret\_name | Name for the graphdb\_data\_encryption\_keystore\_filepath property in App Configuration | `string` | `"graphdb_data_encryption_keystore_filepath"` | no |
 | graphdb\_data\_encryption\_keystore\_filepath | Local path to a keystore file containing the master key for encryption at rest setup | `string` | `""` | no |
 | graphdb\_data\_encryption\_keystore\_password | The keystore password for the data encryption keystore (when using type pkcs12) | `string` | `""` | no |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -307,16 +307,23 @@ module "graphdb" {
   # GraphDB Configurations
   graphdb_external_address_fqdn = var.graphdb_external_address_fqdn != null ? var.graphdb_external_address_fqdn : (var.gateway_enable_private_access ? module.application_gateway[0].private_ip_address : (var.disable_agw ? null : module.application_gateway[0].public_ip_address_fqdn))
 
-  graphdb_password                     = var.graphdb_password
-  graphdb_license_path                 = var.graphdb_license_path
-  graphdb_cluster_token                = var.graphdb_cluster_token
-  graphdb_properties_path              = var.graphdb_properties_path
-  graphdb_java_options                 = var.graphdb_java_options
-  graphdb_audit_log_enabled            = var.graphdb_audit_log_enabled
-  graphdb_audit_log_role               = var.graphdb_audit_log_role
-  graphdb_audit_log_repository         = var.graphdb_audit_log_repository
-  graphdb_audit_log_headers            = var.graphdb_audit_log_headers
-  graphdb_audit_log_max_request_length = var.graphdb_audit_log_max_request_length
+  graphdb_password                               = var.graphdb_password
+  graphdb_license_path                           = var.graphdb_license_path
+  graphdb_cluster_token                          = var.graphdb_cluster_token
+  graphdb_properties_path                        = var.graphdb_properties_path
+  graphdb_java_options                           = var.graphdb_java_options
+  graphdb_audit_log_enabled                      = var.graphdb_audit_log_enabled
+  graphdb_audit_log_role                         = var.graphdb_audit_log_role
+  graphdb_audit_log_repository                   = var.graphdb_audit_log_repository
+  graphdb_audit_log_headers                      = var.graphdb_audit_log_headers
+  graphdb_audit_log_max_request_length           = var.graphdb_audit_log_max_request_length
+  graphdb_data_encryption_type                   = var.graphdb_data_encryption_type
+  graphdb_data_encryption_master_key_filepath    = var.graphdb_data_encryption_master_key_filepath
+  graphdb_data_encryption_master_key_secret_name = var.graphdb_data_encryption_master_key_secret_name
+  graphdb_data_encryption_keystore_alias         = var.graphdb_data_encryption_keystore_alias
+  graphdb_data_encryption_keystore_secret_name   = var.graphdb_data_encryption_keystore_secret_name
+  graphdb_data_encryption_keystore_filepath      = var.graphdb_data_encryption_keystore_filepath
+  graphdb_data_encryption_keystore_password      = var.graphdb_data_encryption_keystore_password
 
   # Backups Storage Account
   backup_storage_account_name   = module.backup.storage_account_name

--- a/modules/graphdb/config.tf
+++ b/modules/graphdb/config.tf
@@ -63,3 +63,20 @@ resource "azurerm_app_configuration_key" "graphdb_node_count" {
   value                  = var.node_count
   content_type           = "text/plain"
 }
+
+resource "azurerm_app_configuration_key" "graphdb_data_encryption_keystore_filepath" {
+  count                  = trimspace(var.graphdb_data_encryption_keystore_filepath) != "" && fileexists(var.graphdb_data_encryption_keystore_filepath) ? 1 : 0
+  configuration_store_id = var.app_configuration_id
+  key                    = var.graphdb_data_encryption_keystore_secret_name
+  value                  = filebase64(var.graphdb_data_encryption_keystore_filepath)
+  content_type           = "text/plain"
+}
+
+resource "azurerm_app_configuration_key" "graphdb_data_encryption_master_key_filepath" {
+  count                  = trimspace(var.graphdb_data_encryption_master_key_filepath) != "" && fileexitsts(var.graphdb_data_encryption_master_key_filepath) ? 1 : 0
+  configuration_store_id = var.app_configuration_id
+  key                    = var.graphdb_data_encryption_master_key_secret_name
+  value                  = filebase64(var.graphdb_data_encryption_master_key_filepath)
+  content_type           = "text/plain"
+}
+

--- a/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
+++ b/modules/graphdb/templates/04_gdb_conf_overrides.sh.tpl
@@ -145,10 +145,37 @@ if [[ $secrets == *"${graphdb_properties_secret_name}"* ]]; then
   az appconfig kv show --endpoint "$APP_CONFIG_ENDPOINT" --auth-mode login --key ${graphdb_properties_secret_name} | jq -r .value | base64 -d >>/etc/graphdb/graphdb.properties
 fi
 
+DATA_ENCRYPTION_TYPE=${graphdb_data_encryption_type}
+ENC_PROPS=""
+if [[ -n "$DATA_ENCRYPTION_TYPE" ]]; then
+  if [[ "$DATA_ENCRYPTION_TYPE" = "file" ]]; then
+    log_with_timestamp "Configuring file-based data encryption."
+    az appconfig kv show --endpoint "$APP_CONFIG_ENDPOINT" --auth-mode login --key ${graphdb_data_encryption_master_key_secret_name} | jq -r .value | base64 -d >/etc/graphdb/master.key
+    chown graphdb:graphdb /etc/graphdb/master.key
+    chmod a-wx,o-rwx /etc/graphdb/master.key
+    ENC_PROPS="-Dgraphdb.data.encryption.type=file -Dgraphdb.data.encryption.file=/etc/graphdb/master.key"
+  elif [[ "$DATA_ENCRYPTION_TYPE" = "pkcs12" ]]; then
+    log_with_timestamp "Configuring pkcs12-based data encryption."
+    az appconfig kv show --endpoint "$APP_CONFIG_ENDPOINT" --auth-mode login --key ${graphdb_data_encryption_keystore_secret_name} | jq -r .value | base64 -d >/etc/graphdb/master.p12
+    chown graphdb:graphdb /etc/graphdb/master.p12
+    chmod a-wx,o-rwx /etc/graphdb/master.p12
+    ENC_PROPS="-Dgraphdb.data.encryption.type=pkcs12 -Dgraphdb.data.encryption.file=/etc/graphdb/master.p12 -Dgraphdb.data.encryption.keystore.alias=${graphdb_data_encryption_keystore_alias} -Dgraphdb.data.encryption.keystore.password=${graphdb_data_encryption_keystore_password}"
+  else
+    log_with_timestamp "Invalid or unsupported data encryption type: $DATA_ENCRYPTION_TYPE. Skipping data encryption"
+  fi
+fi
+
+extra_graphdb_java_options=""
 if [[ $secrets == *"${graphdb_java_options_secret_name}"* ]]; then
   log_with_timestamp "Using GDB_JAVA_OPTS overrides"
   extra_graphdb_java_options=$(az appconfig kv show --endpoint "$APP_CONFIG_ENDPOINT" --auth-mode login --key ${graphdb_java_options_secret_name} | jq -r .value | base64 -d)
-  if grep GDB_JAVA_OPTS &>/dev/null /etc/graphdb/graphdb.env; then
+fi
+if [[ -n $ENC_PROPS ]]; then
+  extra_graphdb_java_options="$extra_graphdb_java_options $ENC_PROPS"
+fi
+
+if [[ -n $extra_graphdb_java_options  ]]; then
+  if grep GDB_JAVA_OPTS /etc/graphdb/graphdb.env &>/dev/null; then
     sed -ie "s|GDB_JAVA_OPTS=\"\(.*\)\"|GDB_JAVA_OPTS=\"\1 $extra_graphdb_java_options\"|g" /etc/graphdb/graphdb.env
   else
     echo "GDB_JAVA_OPTS=$extra_graphdb_java_options" > /etc/graphdb/graphdb.env

--- a/modules/graphdb/user_data.tf
+++ b/modules/graphdb/user_data.tf
@@ -117,6 +117,12 @@ data "cloudinit_config" "entrypoint" {
       graphdb_audit_log_repository : var.graphdb_audit_log_repository
       graphdb_audit_log_headers : var.graphdb_audit_log_headers
       graphdb_audit_log_max_request_length : var.graphdb_audit_log_max_request_length
+      graphdb_data_encryption_type : var.graphdb_data_encryption_type
+      graphdb_data_encryption_keystore_secret_name : var.graphdb_data_encryption_keystore_secret_name
+      graphdb_data_encryption_keystore_alias : var.graphdb_data_encryption_keystore_alias
+      graphdb_data_encryption_keystore_password : var.graphdb_data_encryption_keystore_password
+      graphdb_data_encryption_master_key_filepath : var.graphdb_data_encryption_master_key_filepath
+      graphdb_data_encryption_master_key_secret_name : var.graphdb_data_encryption_master_key_secret_name
     })
   }
 

--- a/modules/graphdb/variables.tf
+++ b/modules/graphdb/variables.tf
@@ -424,3 +424,39 @@ variable "graphdb_audit_log_max_request_length" {
   description = "Maximum number of bytes from the request body to include in the audit log. Defaults to 1024 when not set."
   type        = number
 }
+
+variable "graphdb_data_encryption_type" {
+  description = "The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12"
+  type        = string
+}
+
+variable "graphdb_data_encryption_master_key_filepath" {
+  description = "The master key, when using file-based data encryption."
+  type        = string
+}
+
+variable "graphdb_data_encryption_master_key_secret_name" {
+  description = "Name for the graphdb_data_encryption_master_key_filepath property in App Configuration"
+  type        = string
+}
+
+variable "graphdb_data_encryption_keystore_alias" {
+  description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
+  type        = string
+}
+
+variable "graphdb_data_encryption_keystore_password" {
+  description = "The keystore password for the data encryption keystore (when using type pkcs12)"
+  type        = string
+  sensitive   = true
+}
+
+variable "graphdb_data_encryption_keystore_secret_name" {
+  description = "Name for the graphdb_data_encryption_keystore_filepath property in App Configuration"
+  type        = string
+}
+
+variable "graphdb_data_encryption_keystore_filepath" {
+  description = "Local path to a keystore file containing the master key for encryption at rest setup"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -791,3 +791,63 @@ variable "m2m_scope" {
   type        = string
   default     = null
 }
+
+variable "graphdb_data_encryption_type" {
+  description = "The type of data encryption (Encryption at rest) to configure for the GraphDB instances. Supported values: '', file, pkcs12"
+  type        = string
+  default     = ""
+  validation {
+    condition     = contains(["", "file", "pkcs12"], var.graphdb_data_encryption_type)
+    error_message = "graphdb_data_encryption_type can be either empty, 'file' or 'pkcs12'"
+  }
+}
+
+variable "graphdb_data_encryption_master_key_filepath" {
+  description = "The master key, when using file-based data encryption."
+  type        = string
+  sensitive   = true
+  default     = ""
+  validation {
+    condition     = var.graphdb_data_encryption_type != "file" || (trimspace(var.graphdb_data_encryption_master_key_filepath) != "" && fileexists(var.graphdb_data_encryption_master_key_filepath))
+    error_message = "Master key variable empty or file was not found"
+  }
+}
+
+variable "graphdb_data_encryption_master_key_secret_name" {
+  description = "Name for the graphdb_data_encryption_master_key_filepath property in App Configuration"
+  type        = string
+  default     = "graphdb_data_encryption_master_key_filepath"
+}
+
+variable "graphdb_data_encryption_keystore_alias" {
+  description = "The alias of the data encryption master key, when stored in a keystore (i.e. when using type pkcs12)"
+  type        = string
+  default     = "masterkey"
+}
+
+variable "graphdb_data_encryption_keystore_secret_name" {
+  description = "Name for the graphdb_data_encryption_keystore_filepath property in App Configuration"
+  type        = string
+  default     = "graphdb_data_encryption_keystore_filepath"
+}
+
+variable "graphdb_data_encryption_keystore_filepath" {
+  description = "Local path to a keystore file containing the master key for encryption at rest setup"
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.graphdb_data_encryption_type != "pkcs12" || (trimspace(var.graphdb_data_encryption_keystore_filepath) != "" && fileexists(var.graphdb_data_encryption_keystore_filepath))
+    error_message = "PKCS12 Keystore variable empty or file was not found"
+  }
+}
+
+variable "graphdb_data_encryption_keystore_password" {
+  description = "The keystore password for the data encryption keystore (when using type pkcs12)"
+  type        = string
+  sensitive   = true
+  default     = ""
+  validation {
+    condition     = var.graphdb_data_encryption_type != "pkcs12" || (trimspace(var.graphdb_data_encryption_keystore_password) != "")
+    error_message = "PKCS12 Keystore password cannot be null when configuring PKCS12-based data encryption"
+  }
+}


### PR DESCRIPTION
## Description

Add support for data encryption at rest configuration

- Adds variables and user_data assignments for the new properties required to configure Encryption at rest
- Adds support for file-based and pkcs12-based encryption at rest configuration
- Adds keystore as ssm parameter, if `pkcs12` encryption at rest is selected
- Adds masterkey as ssm parameter, if `file` encryption at rest mode is selected
- Updates 04_gdb_conf_overrides.sh.tpl to configure encryption at rest based on mode selected
- Updated Changelog

## Related Issues

[Jira](https://graphwise.atlassian.net/browse/GDB-14725)

## Changes

## Screenshots (if applicable)


## Checklist

- [X] I have tested these changes thoroughly.
- [X] My code follows the project's coding style.
- [X] I have added appropriate comments to my code, especially in complex areas.
- [X] All new and existing tests passed locally.
